### PR TITLE
Update trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,8 @@ jobs:
   publish:
     needs: release
     environment:
-      name: publish
+      name: pypi
+      url: https://pypi.org/p/ankaios-sdk
     permissions:
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to the last change to trusted publishers in [here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5053#note_2850917), the trusted publisher workflow file and environment changed. This PR updated this as well.