### PR TITLE
Add UpdateStateSuccess object

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the state of the Ankaios system and the connected agents.
 
 Example:
 ```python
-from ankaios_sdk import Workload, Ankaios, WorkloadStateEnum
+from ankaios_sdk import Workload, Ankaios, WorkloadStateEnum, AnkaiosException
 
 # Create a new Ankaios object.
 # The connection to the control interface is automatically done at this step.
@@ -80,28 +80,33 @@ workload = Workload.builder() \
   .runtime_config("image: docker.io/library/nginx\ncommandOptions: [\"-p\", \"8080:80\"]") \
   .build()
 
-# Run the workload
-ret = ankaios.apply_workload(workload)
-
-# Get the WorkloadInstanceName to check later if the workload is running
-workload_instance_name = ret.added_workloads[0]
-
-# Request the execution state based on the workload instance name
-ret = ankaios.get_execution_state_for_instance_name(workload_instance_name)
-if ret is not None:
-  print(f"State: {ret.state}, substate: {ret.substate}, info: {ret.additional_info}")
-
-# Wait until the workload reaches the running state
 try:
-  ankaios.wait_for_workload_to_reach_state(
-    workload_instance_name,
-    state=WorkloadStateEnum.RUNNING,
-    timeout=5
-    )
-except TimeoutError:
-  print("Workload didn't reach the required state in time.")
-else:
-  print("Workload reached the RUNNING state.")
+  # Run the workload
+  update_response = ankaios.apply_workload(workload)
+
+  # Get the WorkloadInstanceName to check later if the workload is running
+  workload_instance_name = update_response.added_workloads[0]
+
+  # Request the execution state based on the workload instance name
+  ret = ankaios.get_execution_state_for_instance_name(workload_instance_name)
+  if ret is not None:
+    print(f"State: {ret.state}, substate: {ret.substate}, info: {ret.additional_info}")
+
+  # Wait until the workload reaches the running state
+  try:
+    ankaios.wait_for_workload_to_reach_state(
+      workload_instance_name,
+      state=WorkloadStateEnum.RUNNING,
+      timeout=5
+      )
+  except TimeoutError:
+    print("Workload didn't reach the required state in time.")
+  else:
+    print("Workload reached the RUNNING state.")
+
+# Catch the AnkaiosException in case something went wrong with apply_workload
+except AnkaiosException as e:
+  print("Ankaios Exception occured: ", e)
 
 # Request the state of the system, filtered with the agent name
 complete_state = ankaios.get_state(

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the state of the Ankaios system and the connected agents.
 
 Example:
 ```python
-from ankaios_sdk import Workload, Ankaios, WorkloadStateEnum, WorkloadSubStateEnum
+from ankaios_sdk import Workload, Ankaios, WorkloadStateEnum
 
 # Create a new Ankaios object.
 # The connection to the control interface is automatically done at this step.
@@ -84,8 +84,7 @@ workload = Workload.builder() \
 ret = ankaios.apply_workload(workload)
 
 # Get the WorkloadInstanceName to check later if the workload is running
-if ret is not None:
-  workload_instance_name = ret["added_workloads"][0]
+workload_instance_name = ret.added_workloads[0]
 
 # Request the execution state based on the workload instance name
 ret = ankaios.get_execution_state_for_instance_name(workload_instance_name)
@@ -93,12 +92,15 @@ if ret is not None:
   print(f"State: {ret.state}, substate: {ret.substate}, info: {ret.additional_info}")
 
 # Wait until the workload reaches the running state
-ret = ankaios.wait_for_workload_to_reach_state(
-  workload_instance_name,
-  state=WorkloadStateEnum.RUNNING,
-  timeout=5
-  )
-if ret:
+try:
+  ankaios.wait_for_workload_to_reach_state(
+    workload_instance_name,
+    state=WorkloadStateEnum.RUNNING,
+    timeout=5
+    )
+except TimeoutError:
+  print("Workload didn't reach the required state in time.")
+else:
   print("Workload reached the RUNNING state.")
 
 # Request the state of the system, filtered with the agent name

--- a/ankaios_sdk/_components/workload_state.py
+++ b/ankaios_sdk/_components/workload_state.py
@@ -57,6 +57,13 @@ Usage
         state = workload_state.execution_state.state
         substate = workload_state.execution_state.substate
         info = workload_state.execution_state.additional_info
+
+- Get the workload instance name as a dictionary:
+    .. code-block:: python
+
+        workload_instance_name = WorkloadInstanceName()
+        instance_name_dict = workload_instance_name.to_dict()
+        json_instance_name = json.dumps(instance_name_dict)
 """
 
 __all__ = ["WorkloadStateCollection", "WorkloadState",
@@ -327,6 +334,19 @@ class WorkloadInstanceName:
             str: The string representation of the workload instance name.
         """
         return f"{self.workload_name}.{self.workload_id}.{self.agent_name}"
+
+    def to_dict(self) -> dict:
+        """
+        Returns the workload instance name as a dictionary.
+
+        Returns:
+            dict: The workload instance name as a dictionary.
+        """
+        return {
+            "agent_name": self.agent_name,
+            "workload_name": self.workload_name,
+            "workload_id": self.workload_id
+        }
 
     def get_filter_mask(self) -> str:
         """

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -34,20 +34,19 @@ Usage
     .. code-block:: python
 
         ret = ankaios.apply_manifest(manifest)
-        print(ret["added_workloads"])
-        print(ret["deleted_workloads"])
+        print(ret.to_dict())
 
 - Delete a manifest:
     .. code-block:: python
 
         ret = ankaios.delete_manifest(manifest)
-        print(ret["deleted_workloads"])
+        print(ret.to_dict())
 
 - Run a workload:
     .. code-block:: python
 
         ret = ankaios.apply_workload(workload)
-        print(ret["added_workloads"])
+        print(ret.to_dict())
 
 - Get a workload:
     .. code-block:: python
@@ -58,7 +57,7 @@ Usage
     .. code-block:: python
 
         ret = ankaios.delete_workload(workload_name)
-        print(ret["deleted_workloads"])
+        print(ret.to_dict())
 
 - Get the state:
     .. code-block:: python
@@ -115,7 +114,8 @@ from ._protos import _control_api
 from .exceptions import AnkaiosConnectionException, AnkaiosException, \
                         ResponseException, ConnectionClosedException
 from ._components import Workload, CompleteState, Request, Response, \
-                         ResponseEvent, WorkloadStateCollection, Manifest, \
+                         UpdateStateSuccess, ResponseEvent, \
+                         WorkloadStateCollection, Manifest, \
                          WorkloadInstanceName, WorkloadStateEnum, \
                          WorkloadExecutionState
 from .utils import AnkaiosLogLevel, get_logger, \
@@ -405,7 +405,8 @@ class Ankaios:
         self.logger.setLevel(level.value)
 
     def apply_manifest(self, manifest: Manifest,
-                       timeout: float = DEFAULT_TIMEOUT) -> dict:
+                       timeout: float = DEFAULT_TIMEOUT
+                       ) -> UpdateStateSuccess:
         """
         Send a request to apply a manifest.
 
@@ -414,7 +415,7 @@ class Ankaios:
             timeout (float): The maximum time to wait for the response.
 
         Returns:
-            dict: a dict with the added and deleted workloads.
+            UpdateStateSuccess: The update state success object.
 
         Raises:
             TimeoutError: If the request timed out.
@@ -442,14 +443,15 @@ class Ankaios:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
-                len(content["added_workloads"]),
-                len(content["deleted_workloads"])
+                len(content.added_workloads),
+                len(content.deleted_workloads)
             )
             return content
         raise AnkaiosException("Received unexpected content type.")
 
     def delete_manifest(self, manifest: Manifest,
-                        timeout: float = DEFAULT_TIMEOUT) -> dict:
+                        timeout: float = DEFAULT_TIMEOUT
+                        ) -> UpdateStateSuccess:
         """
         Send a request to delete a manifest.
 
@@ -458,7 +460,7 @@ class Ankaios:
             timeout (float): The maximum time to wait for the response.
 
         Returns:
-            dict: a dict with the added and deleted workloads.
+            UpdateStateSuccess: The update state success object.
 
         Raises:
             TimeoutError: If the request timed out.
@@ -486,14 +488,15 @@ class Ankaios:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
-                len(content["added_workloads"]),
-                len(content["deleted_workloads"])
+                len(content.added_workloads),
+                len(content.deleted_workloads)
             )
             return content
         raise AnkaiosException("Received unexpected content type.")
 
     def apply_workload(self, workload: Workload,
-                       timeout: float = DEFAULT_TIMEOUT) -> dict:
+                       timeout: float = DEFAULT_TIMEOUT
+                       ) -> UpdateStateSuccess:
         """
         Send a request to run a workload.
 
@@ -502,7 +505,7 @@ class Ankaios:
             timeout (float): The maximum time to wait for the response.
 
         Returns:
-            dict: a dict with the added and deleted workloads.
+            UpdateStateSuccess: The update state success object.
 
         Raises:
             TimeoutError: If the request timed out.
@@ -533,8 +536,8 @@ class Ankaios:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
-                len(content["added_workloads"]),
-                len(content["deleted_workloads"])
+                len(content.added_workloads),
+                len(content.deleted_workloads)
             )
             return content
         raise AnkaiosException("Received unexpected content type.")
@@ -558,7 +561,8 @@ class Ankaios:
         ).get_workloads()[0]
 
     def delete_workload(self, workload_name: str,
-                        timeout: float = DEFAULT_TIMEOUT) -> dict:
+                        timeout: float = DEFAULT_TIMEOUT
+                        ) -> UpdateStateSuccess:
         """
         Send a request to delete a workload.
 
@@ -567,7 +571,7 @@ class Ankaios:
             timeout (float): The maximum time to wait for the response.
 
         Returns:
-            dict: a dict with the added and deleted workloads.
+            UpdateStateSuccess: The update state success object.
 
         Raises:
             TimeoutError: If the request timed out.
@@ -593,8 +597,8 @@ class Ankaios:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
-                len(content["added_workloads"]),
-                len(content["deleted_workloads"])
+                len(content.added_workloads),
+                len(content.deleted_workloads)
             )
             return content
         raise AnkaiosException("Received unexpected content type.")
@@ -801,7 +805,7 @@ class Ankaios:
 
     def get_agents(
             self, timeout: float = DEFAULT_TIMEOUT
-            ) -> list[str]:
+            ) -> dict:
         """
         Get the agents from the requested complete state.
 
@@ -810,7 +814,7 @@ class Ankaios:
                 in seconds.
 
         Returns:
-            list[str]: The list of agent names.
+            dict: The agents dictionary.
         """
         return self.get_state(timeout).get_agents()
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -47,7 +47,7 @@ The manifest can now be applied using the following code:
     ret = ankaios.apply_manifest(manifest)
 
     # Get the workload instance name
-    wl_instance_name = ret["added_workloads"][0]
+    wl_instance_name = ret.added_workloads[0]
 
     # Print the instance name
     print(wl_instance_name)
@@ -60,7 +60,7 @@ The manifest can now be applied using the following code:
     print(execution_state.substate)
     print(execution_state.additional_info)
 
-If the operation is successful, the result will contain a list with the added workloads that contains the workload instance name of the newly added workload.
+If the operation is successful, the result will be an UpdateStateSuccess object that contains the added and deleted workload instance names.
 The workload instance name contains the name of the workload, the agent it is running on and a unique identifier. Using it, we can request the current execution state of
 the workload. The state has 3 elements: the primary state, the substate and additional information (See `Workload States <workload_state.html>`_).
 
@@ -105,8 +105,8 @@ the exact workload we want to modify, we must know only it's name.
     ret = workload.update_restart_policy("ALWAYS")
 
     # Unpack the result
-    added_workloads = ret["added_workloads"]
-    deleted_workloads = ret["deleted_workloads"]
+    added_workloads = ret.added_workloads
+    deleted_workloads = ret.deleted_workloads
 
 Depending on the updated parameter, the workload can be restarted or not. If this is the case, the ``deleted_workloads`` will contain the old instance name and 
 the ``added_workloads`` will contain the new one.
@@ -131,7 +131,7 @@ delete the workload based on its name. In this example, we will delete the workl
     ret = ankaios.delete_manifest(manifest)
 
     # Get the workload instance name
-    wl_instance_name = ret["deleted_workloads"][0]
+    wl_instance_name = ret.deleted_workloads[0]
 
     # Print the instance name of the deleted workload
     print(wl_instance_name)

--- a/docs/source/response.rst
+++ b/docs/source/response.rst
@@ -20,3 +20,12 @@ ResponseEvent Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+UpdateStateSuccess Class
+------------------------
+
+.. autoclass:: ankaios_sdk._components.response.UpdateStateSuccess
+    :special-members: __init__, __str__
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/response/test_response.py
+++ b/tests/response/test_response.py
@@ -92,8 +92,8 @@ def test_initialisation():
     # Test UpdateStateSuccess message
     response = Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
     assert response.content_type == "update_state_success"
-    added_workloads = response.content["added_workloads"]
-    deleted_workloads = response.content["deleted_workloads"]
+    added_workloads = response.content.added_workloads
+    deleted_workloads = response.content.deleted_workloads
     assert len(added_workloads) == 1
     assert len(deleted_workloads) == 1
     assert str(added_workloads[0]) == "new_nginx.12345.agent_A"

--- a/tests/response/test_update_state_success.py
+++ b/tests/response/test_update_state_success.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module contains unit tests for the UpdateStateSuccess
+class in the ankaios_sdk.
+"""
+
+from ankaios_sdk import UpdateStateSuccess, WorkloadInstanceName
+
+
+def test_functionality():
+    """
+    Test the methods of an UpdateStateSuccess instance.
+    """
+    update_state_success = UpdateStateSuccess()
+
+    assert update_state_success is not None
+    assert len(update_state_success.added_workloads) == 0
+    assert len(update_state_success.deleted_workloads) == 0
+
+    update_state_success.added_workloads.append(
+        WorkloadInstanceName("agent_A", "new_nginx", "12345")
+        )
+    update_state_success.deleted_workloads.append(
+        WorkloadInstanceName("agent_A", "old_nginx", "54321")
+    )
+
+    assert len(update_state_success.added_workloads) == 1
+    assert len(update_state_success.deleted_workloads) == 1
+    assert str(update_state_success) == \
+        "Added workloads: ['new_nginx.12345.agent_A'], " \
+        "Deleted workloads: ['old_nginx.54321.agent_A']"
+    assert update_state_success.to_dict() == {
+        "added_workloads": [
+            {
+                "agent_name": "agent_A",
+                "workload_name": "new_nginx",
+                "workload_id": "12345"
+            }
+        ],
+        "deleted_workloads": [
+            {
+                "agent_name": "agent_A",
+                "workload_name": "old_nginx",
+                "workload_id": "54321"
+            }
+        ]
+    }

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -23,8 +23,9 @@ import threading
 from unittest.mock import patch, mock_open, MagicMock
 import pytest
 from ankaios_sdk import Ankaios, AnkaiosLogLevel, Response, ResponseEvent, \
-    Manifest, CompleteState, WorkloadInstanceName, WorkloadStateCollection, \
-    WorkloadStateEnum, AnkaiosConnectionException, AnkaiosException
+    UpdateStateSuccess, Manifest, CompleteState, WorkloadInstanceName, \
+    WorkloadStateCollection, WorkloadStateEnum, AnkaiosConnectionException, \
+    AnkaiosException
 from ankaios_sdk.utils import WORKLOADS_PREFIX, ANKAIOS_VERSION
 from ankaios_sdk._protos import _control_api
 from tests.workload.test_workload import generate_test_workload
@@ -306,7 +307,7 @@ def test_apply_manifest():
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
         ret = ankaios.apply_manifest(manifest)
-        assert isinstance(ret, dict)
+        assert isinstance(ret, UpdateStateSuccess)
         mock_send_request.assert_called_once()
         ankaios.logger.info.assert_called()
 
@@ -349,7 +350,7 @@ def test_delete_manifest():
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
         ret = ankaios.delete_manifest(manifest)
-        assert isinstance(ret, dict)
+        assert isinstance(ret, UpdateStateSuccess)
         mock_send_request.assert_called_once()
         ankaios.logger.info.assert_called()
 
@@ -392,7 +393,7 @@ def test_apply_workload():
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
         ret = ankaios.apply_workload(workload)
-        assert isinstance(ret, dict)
+        assert isinstance(ret, UpdateStateSuccess)
         mock_send_request.assert_called_once()
         ankaios.logger.info.assert_called()
 
@@ -458,7 +459,7 @@ def test_delete_workload():
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
         ret = ankaios.delete_workload("nginx")
-        assert isinstance(ret, dict)
+        assert isinstance(ret, UpdateStateSuccess)
         mock_send_request.assert_called_once()
         ankaios.logger.info.assert_called()
 

--- a/tests/workload_state/test_workload_instance_name.py
+++ b/tests/workload_state/test_workload_instance_name.py
@@ -37,6 +37,11 @@ def test_methods():
     assert str(workload_instance_name) == "workload_Test.1234.agent_Test"
     assert workload_instance_name.get_filter_mask() == \
         "workloadStates.agent_Test.workload_Test.1234"
+    assert workload_instance_name.to_dict() == {
+        "agent_name": "agent_Test",
+        "workload_name": "workload_Test",
+        "workload_id": "1234"
+    }
 
 
 def test_equality():


### PR DESCRIPTION
Issues: The returned value in case of an update state success was a dictionary with custom objects. This was not directly serializable and was difficult to work with. This object handles these cases automatically.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
