### PR TITLE
Add RequestType and ResponseType Enums

### DIFF
--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -122,9 +122,9 @@ from google.protobuf.internal.decoder import _DecodeVarint
 from ._protos import _control_api
 from .exceptions import AnkaiosConnectionException, AnkaiosException, \
                         ResponseException, ConnectionClosedException
-from ._components import Workload, CompleteState, Request, Response, \
-                         UpdateStateSuccess, ResponseEvent, \
-                         WorkloadStateCollection, Manifest, \
+from ._components import Workload, CompleteState, Request, RequestType, \
+                         Response, ResponseType, UpdateStateSuccess, \
+                         ResponseEvent, WorkloadStateCollection, Manifest, \
                          WorkloadInstanceName, WorkloadStateEnum, \
                          WorkloadExecutionState
 from .utils import AnkaiosLogLevel, get_logger, \
@@ -462,7 +462,7 @@ class Ankaios:
             AnkaiosException: If an error occurred while applying
                 the manifest.
         """
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(CompleteState.from_manifest(manifest))
         request.set_masks(manifest._calculate_masks())
 
@@ -475,11 +475,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to apply manifest: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
@@ -507,7 +507,7 @@ class Ankaios:
             AnkaiosException: If an error occurred while deleting
                 the manifest.
         """
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(CompleteState())
         request.set_masks(manifest._calculate_masks())
 
@@ -520,11 +520,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete manifest: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
@@ -555,7 +555,7 @@ class Ankaios:
         complete_state.add_workload(workload)
 
         # Create the request
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(complete_state)
         request.set_masks(workload.masks)
 
@@ -568,11 +568,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to run workload: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
@@ -617,7 +617,7 @@ class Ankaios:
             TimeoutError: If the request timed out.
             AnkaiosException: If an error occurred while deleting the workload.
         """
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(CompleteState())
         request.add_mask(f"{WORKLOADS_PREFIX}.{workload_name}")
 
@@ -629,11 +629,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete workload: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
                 + "%s deleted workloads.",
@@ -659,7 +659,7 @@ class Ankaios:
         complete_state = CompleteState()
         complete_state.set_configs(configs)
 
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(complete_state)
         request.add_mask(CONFIGS_PREFIX)
 
@@ -671,11 +671,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to set the configs: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
         raise AnkaiosException("Received unexpected content type.")
@@ -698,7 +698,7 @@ class Ankaios:
         complete_state = CompleteState()
         complete_state.set_configs({name: config})
 
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(complete_state)
         request.add_mask(f"{CONFIGS_PREFIX}.{name}")
 
@@ -710,11 +710,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to add the config: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
         raise AnkaiosException("Received unexpected content type.")
@@ -752,7 +752,7 @@ class Ankaios:
             TimeoutError: If the request timed out.
             AnkaiosException: If an error occurred.
         """
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(CompleteState())
         request.add_mask(CONFIGS_PREFIX)
 
@@ -764,11 +764,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete all configs: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
         raise AnkaiosException("Received unexpected content type.")
@@ -785,7 +785,7 @@ class Ankaios:
             TimeoutError: If the request timed out.
             AnkaiosException: If an error occurred.
         """
-        request = Request(request_type="update_state")
+        request = Request(request_type=RequestType.UPDATE_STATE)
         request.set_complete_state(CompleteState())
         request.add_mask(f"{CONFIGS_PREFIX}.{name}")
 
@@ -797,11 +797,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete all configs: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "update_state_success":
+        if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
         raise AnkaiosException("Received unexpected content type.")
@@ -824,7 +824,7 @@ class Ankaios:
             TimeoutError: If the request timed out.
             AnkaiosException: If an error occurred while getting the state.
         """
-        request = Request(request_type="get_state")
+        request = Request(request_type=RequestType.GET_STATE)
         if field_masks is not None:
             request.set_masks(field_masks)
         try:
@@ -835,11 +835,11 @@ class Ankaios:
 
         # Interpret response
         (content_type, content) = response.get_content()
-        if content_type == "error":
+        if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to get the state: %s",
                               content)
             raise AnkaiosException(f"Received error: {content}")
-        if content_type == "complete_state":
+        if content_type == ResponseType.COMPLETE_STATE:
             return content
         raise AnkaiosException("Received unexpected content type.")
 

--- a/docs/source/request.rst
+++ b/docs/source/request.rst
@@ -11,3 +11,12 @@ Request Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+RequestType Enum
+-----------------
+
+.. autoclass:: ankaios_sdk._components.request.RequestType
+    :special-members: __str__
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/response.rst
+++ b/docs/source/response.rst
@@ -29,3 +29,12 @@ UpdateStateSuccess Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+ResponseType Enum
+-----------------
+
+.. autoclass:: ankaios_sdk._components.response.ResponseType
+    :special-members: __str__
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/workload_state.rst
+++ b/docs/source/workload_state.rst
@@ -39,8 +39,8 @@ WorkloadStateCollection Class
     :undoc-members:
     :show-inheritance:
 
-WorkloadStateEnum Enum
-----------------------
+WorkloadStateEnum
+-----------------
 
 .. autoclass:: ankaios_sdk._components.workload_state.WorkloadStateEnum
     :special-members: __str__
@@ -48,8 +48,8 @@ WorkloadStateEnum Enum
     :undoc-members:
     :show-inheritance:
 
-WorkloadSubStateEnum Enum
--------------------------
+WorkloadSubStateEnum
+--------------------
 
 .. autoclass:: ankaios_sdk._components.workload_state.WorkloadSubStateEnum
     :special-members: __str__

--- a/tests/response/test_response.py
+++ b/tests/response/test_response.py
@@ -18,8 +18,8 @@ This module contains unit tests for the Response class in the ankaios_sdk.
 
 import pytest
 from google.protobuf.internal.encoder import _VarintBytes
-from ankaios_sdk import Response, CompleteState, ResponseException, \
-    ConnectionClosedException
+from ankaios_sdk import Response, ResponseType, CompleteState, \
+    ResponseException, ConnectionClosedException
 from ankaios_sdk._protos import _ank_base, _control_api
 
 
@@ -81,17 +81,17 @@ def test_initialisation():
     """
     # Test error message
     response = Response(MESSAGE_BUFFER_ERROR)
-    assert response.content_type == "error"
+    assert response.content_type == ResponseType.ERROR
     assert response.content == "Test error message"
 
     # Test CompleteState message
     response = Response(MESSAGE_BUFFER_COMPLETE_STATE)
-    assert response.content_type == "complete_state"
+    assert response.content_type == ResponseType.COMPLETE_STATE
     assert isinstance(response.content, CompleteState)
 
     # Test UpdateStateSuccess message
     response = Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
-    assert response.content_type == "update_state_success"
+    assert response.content_type == ResponseType.UPDATE_STATE_SUCCESS
     added_workloads = response.content.added_workloads
     deleted_workloads = response.content.deleted_workloads
     assert len(added_workloads) == 1
@@ -119,7 +119,10 @@ def test_getters():
     """
     response = Response(MESSAGE_BUFFER_ERROR)
     assert response.get_request_id() == "1234"
-    assert response.get_content() == ("error", "Test error message")
+    content_type, content = response.get_content()
+    assert content_type == ResponseType.ERROR
+    assert str(content_type) == "error"
+    assert content == "Test error message"
 
 
 def test_check_request_id():

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -17,7 +17,7 @@ This module contains unit tests for the Request class in the ankaios_sdk.
 """
 
 import pytest
-from ankaios_sdk import Request, CompleteState, RequestException
+from ankaios_sdk import Request, RequestType, CompleteState, RequestException
 from tests.workload.test_workload import generate_test_workload
 
 
@@ -29,12 +29,12 @@ def generate_test_request(request_type: str = "update_state") -> Request:
         Request: A Request instance.
     """
     if request_type == "update_state":
-        request = Request("update_state")
+        request = Request(RequestType.UPDATE_STATE)
         complete_state = CompleteState()
         complete_state.add_workload(generate_test_workload())
         request.set_complete_state(complete_state)
         return request
-    return Request("get_state")
+    return Request(RequestType.GET_STATE)
 
 
 def test_general_functionality():
@@ -44,7 +44,7 @@ def test_general_functionality():
     with pytest.raises(RequestException, match="Invalid request type."):
         Request("invalid")
 
-    request = Request("update_state")
+    request = Request(RequestType.UPDATE_STATE)
     assert request.get_id() is not None
     assert str(request) == f"requestId: \"{request.get_id()}\"\n" \
         + "updateStateRequest {\n}\n"
@@ -54,7 +54,7 @@ def test_update_state():
     """
     Test the update state request type.
     """
-    request = Request("update_state")
+    request = Request(RequestType.UPDATE_STATE)
     complete_state = CompleteState()
     request.set_complete_state(complete_state)
     assert request._request.updateStateRequest.newState == \
@@ -67,14 +67,14 @@ def test_update_state():
             RequestException,
             match="Complete state can only be set for an update state request."
             ):
-        Request("get_state").set_complete_state(CompleteState())
+        Request(RequestType.GET_STATE).set_complete_state(CompleteState())
 
 
 def test_get_state():
     """
     Test the get state request type.
     """
-    request = Request("get_state")
+    request = Request(RequestType.GET_STATE)
     request.add_mask("test_mask")
     assert request._request.completeStateRequest.fieldMask == ["test_mask"]
 
@@ -83,8 +83,8 @@ def test_proto():
     """
     Test the conversion to proto message.
     """
-    request = Request("update_state")
+    request = Request(RequestType.UPDATE_STATE)
     assert request._to_proto().requestId == request.get_id()
 
-    request = Request("get_state")
+    request = Request(RequestType.GET_STATE)
     assert request._to_proto().requestId == request.get_id()


### PR DESCRIPTION
Issue: The Request and Response classes were using simple string to specify the type. This PR adds enums for each of them.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
