### PR TITLE
Control interface

### DIFF
--- a/ankaios_sdk/__init__.py
+++ b/ankaios_sdk/__init__.py
@@ -13,29 +13,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Ankaios Python SDK
-
-Classes
--------
-
-- Ankaios:
-    The main SDK class.
-- Workload:
-    Represents a workload.
-- WorkloadBuilder:
-    A builder class for workloads.
-- WorkloadState:
-    Represents the state of a workload.
-- WorkloadStateCollection:
-    A collection of workload states.
-- Manifest:
-    Represents a workload manifest.
-- CompleteState:
-    Represents the complete state of the Ankaios cluster.
+Ankaios Python SDK main imports.
 """
 
 from .exceptions import *
 from .ankaios import *
 from ._components import *
+from .utils import AnkaiosLogLevel
 
 __all__ = [name for name in globals() if not name.startswith('_')]

--- a/ankaios_sdk/_components/__init__.py
+++ b/ankaios_sdk/_components/__init__.py
@@ -39,5 +39,6 @@ from .complete_state import *
 from .request import *
 from .response import *
 from .manifest import *
+from .control_interface import *
 
 __all__ = [name for name in globals() if not name.startswith('_')]

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -277,7 +277,7 @@ class ControlInterface:
                     if next_byte[0] & MOST_SIGNIFICANT_BIT_MASK == 0:
                         break
 
-                if not varint_buffer:  # pragma: no cover
+                if not varint_buffer:
                     if self._state != ControlInterfaceState.AGENT_DISCONNECTED:
                         self.change_state(
                             ControlInterfaceState.AGENT_DISCONNECTED)

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2024 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script defines the ControlInterface class that handles the writing
+and reading of data to and from the Ankaios control interface.
+
+Classes
+-------
+
+- ControlInterface:
+    Handles the interaction with the Ankaios control interface.
+
+Enums
+-----
+
+- ControlInterfaceState:
+    Represents the state of the control interface.
+"""
+
+
+__all__ = ["ControlInterface", "ControlInterfaceState"]
+
+
+import os
+import select
+import threading
+from typing import Callable
+from enum import Enum
+from google.protobuf.internal.encoder import _VarintBytes
+from google.protobuf.internal.decoder import _DecodeVarint
+
+from .._protos import _control_api
+from .request import Request
+from .response import Response, ResponseException
+from ..exceptions import AnkaiosConnectionException, ConnectionClosedException
+from ..utils import DEFAULT_CONTROL_INTERFACE_PATH, get_logger, ANKAIOS_VERSION
+
+
+class ControlInterfaceState(Enum):
+    """ The state of the control interface. """
+    CONNECTED = 1
+    "(int): Connected state."
+    DISCONNECTED = 2
+    "(int): Disconnected state."
+    AGENT_DISCONNECTED = 3
+    "(int): Agent disconnected state."
+    CONNECTION_CLOSED = 4
+    "(int): Connection closed state."
+
+    def __str__(self) -> str:
+        """
+        Returns the string representation of the state.
+
+        Returns:
+            str: The state as a string.
+        """
+        return self.name
+
+
+class ControlInterface:
+    """
+    This class handles the interaction with the Ankaios control interface.
+    It provides method to send and receive data to and from the control
+    interface pipes.
+
+    Attributes:
+        logger (logging.Logger): The logger for the Ankaios class.
+        path (str): The path to the control interface.
+    """
+    ANKAIOS_CONTROL_INTERFACE_BASE_PATH = "/run/ankaios/control_interface"
+    "(str): The base path for the Ankaios control interface."
+
+    def __init__(self,
+                 add_response_callback: Callable,
+                 state_changed_callback: Callable
+                 ) -> None:
+        """
+        Initialize the ControlInterface object. This will also connect to
+        the control interface pipes.
+        """
+        self.path = DEFAULT_CONTROL_INTERFACE_PATH
+        self._input_file = None
+        self._output_file = None
+        self.state = ControlInterfaceState.DISCONNECTED
+        self._read_thread = None
+        self._disconnect_event = threading.Event()
+
+        self._add_response_callback = add_response_callback
+        self._state_changed_callback = state_changed_callback
+
+        self.logger = get_logger()
+
+    def connect(self) -> None:
+        """
+        Connect to the control interface by starting to read
+        from the input fifo and opening the output fifo.
+
+        Raises:
+            AnkaiosConnectionException: If an error occurred.
+        """
+        if self.state == ControlInterfaceState.CONNECTED:
+            raise AnkaiosConnectionException("Already connected.")
+
+        if not os.path.exists(
+                f"{self.ANKAIOS_CONTROL_INTERFACE_BASE_PATH}/input"):
+            raise AnkaiosConnectionException(
+                "Control interface input fifo does not exist."
+            )
+
+        if not os.path.exists(
+                f"{self.ANKAIOS_CONTROL_INTERFACE_BASE_PATH}/output"):
+            raise AnkaiosConnectionException(
+                "Control interface output fifo does not exist."
+            )
+
+        # pylint: disable=consider-using-with
+        try:
+            self._output_file = open(
+                f"{self.ANKAIOS_CONTROL_INTERFACE_BASE_PATH}/output", "ab"
+            )
+        except Exception as e:
+            self.logger.error("Error while opening output fifo: %s", e)
+            self.disconnect()
+            raise AnkaiosConnectionException(
+                "Error while opening output fifo."
+            ) from e
+
+        self._read_thread = threading.Thread(
+            target=self._read_from_control_interface,
+            daemon=True
+        )
+        self.change_state(ControlInterfaceState.CONNECTED)
+        self._read_thread.start()
+        self._send_initial_hello()
+
+    def disconnect(self) -> None:
+        """
+        Disconnect from the control interface.
+        """
+        if not self.state == ControlInterfaceState.DISCONNECTED:
+            self.logger.debug("Already disconnected.")
+            return
+
+        self.logger.debug("Disconnecting..")
+        self._disconnect_event.set()
+        if self._read_thread is not None:
+            self._read_thread.join(timeout=2)
+            if self._read_thread.is_alive():
+                self.logger.error("Read thread did not stop.")
+            self._read_thread = None
+        self._cleanup()
+
+    def _cleanup(self) -> None:
+        """
+        Clean up the resources.
+        """
+        self.change_state(ControlInterfaceState.DISCONNECTED)
+        if self._output_file is not None:
+            self._output_file.close()
+            self._output_file = None
+        self.logger.debug("Cleanup happened")
+
+    def change_state(self, state: ControlInterfaceState) -> None:
+        """
+        Change the state of the control interface.
+
+        Args:
+            state (ControlInterfaceState): The new state.
+        """
+        self.state = state
+        self._state_changed_callback(state)
+
+        if self.state == ControlInterfaceState.AGENT_DISCONNECTED:
+            self._disconnect_event.set()
+            self._cleanup()
+
+    def _read_from_control_interface(self) -> None:
+        """
+        Reads from the control interface input fifo.
+        This is meant to be run in a separate thread.
+        The responses are then sent to the Ankaios class to be handled.
+
+        Raises:
+            AnkaiosConnectionException: If an error occurs
+                while reading the fifo.
+        """
+        # The pragma: no cover is used on small checks that are not expected
+        # to fail. This method is difficult to test and testing each check
+        # would be redundant.
+
+        # pylint: disable=invalid-name
+        MOST_SIGNIFICANT_BIT_MASK = 0b10000000
+
+        # pylint: disable=consider-using-with
+        try:
+            self._input_file = open(
+                f"{self.ANKAIOS_CONTROL_INTERFACE_BASE_PATH}/input", "rb"
+            )
+        except Exception as e:
+            self.logger.error("Error while opening input fifo: %s", e)
+            self.disconnect()
+            raise AnkaiosConnectionException(
+                "Error while opening input fifo."
+            ) from e
+        os.set_blocking(self._input_file.fileno(), False)
+
+        try:
+            self.logger.info("Started reading from the input pipe.")
+
+            while not self._disconnect_event.is_set():
+                # The loop continues when data is available or when the
+                # timeout of 1 second is reached.
+                ready, _, _ = select.select([self._input_file], [], [], 1)
+                if not ready:  # pragma: no cover
+                    continue
+
+                # Buffer for reading in the byte size of the proto msg
+                varint_buffer = bytearray()
+                while not self._disconnect_event.is_set():
+                    # Consume byte for byte
+                    next_byte = self._input_file.read(1)
+                    if not next_byte:  # pragma: no cover
+                        break
+                    varint_buffer += next_byte
+                    # Check if we reached the last byte
+                    if next_byte[0] & MOST_SIGNIFICANT_BIT_MASK == 0:
+                        break
+
+                if not varint_buffer:  # pragma: no cover
+                    self.change_state(ControlInterfaceState.AGENT_DISCONNECTED)
+
+                # Decode the varint and receive the proto msg length
+                msg_len, _ = _DecodeVarint(varint_buffer, 0)
+
+                # Buffer for the proto msg itself
+                msg_buf = bytearray()
+                for _ in range(msg_len):
+                    # Read the message according to the length
+                    next_byte = self._input_file.read(1)
+                    if not next_byte:  # pragma: no cover
+                        break
+                    msg_buf += next_byte
+
+                try:
+                    response = Response(bytes(msg_buf))
+                except ResponseException as e:  # pragma: no cover
+                    self.logger.error("Error while reading: %s", e)
+                    continue
+                except ConnectionClosedException as e:  # pragma: no cover
+                    self.logger.error("Connection closed: %s", e)
+                    self.change_state(ControlInterfaceState.CONNECTION_CLOSED)
+                    break
+
+                self._add_response_callback(response)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self.logger.error("Error while reading fifo file: %s", e)
+        finally:
+            if self.state == ControlInterfaceState.CONNECTED:
+                self.change_state(ControlInterfaceState.DISCONNECTED)
+            self._input_file.close()
+            self._cleanup()
+
+    def _write_to_pipe(self, to_ankaios: _control_api.ToAnkaios) -> None:
+        """
+        Writes the ToAnkaios proto message to the control
+        interface output fifo.
+
+        Args:
+            to_ankaios (_control_api.ToAnkaios): The ToAnkaios proto message.
+        """
+        # Adds the byte length of the proto msg
+        self._output_file.write(_VarintBytes(to_ankaios.ByteSize()))
+        # Adds the proto msg itself
+        self._output_file.write(to_ankaios.SerializeToString())
+        self._output_file.flush()
+
+    def write_request(self, request: Request) -> None:
+        """
+        Writes the request into the control interface output fifo.
+
+        Args:
+            request (Request): The request object to be written.
+
+        Raises:
+            AnkaiosConnectionException: If not connected.
+        """
+        if not self.state == ControlInterfaceState.CONNECTED:
+            raise AnkaiosConnectionException(
+                "Could not write to pipe, not connected.")
+
+        request_to_ankaios = _control_api.ToAnkaios(
+            request=request._to_proto()
+        )
+        self._write_to_pipe(request_to_ankaios)
+
+    def _send_initial_hello(self) -> None:
+        """
+        Send an initial hello message to the control interface with
+        the version in order to check it.
+
+        Raises:
+            AnkaiosConnectionException: If an error occurred.
+        """
+        initial_hello = _control_api.ToAnkaios(
+            hello=_control_api.Hello(
+                protocolVersion=str(ANKAIOS_VERSION)
+            )
+        )
+        self._write_to_pipe(initial_hello)
+        self.logger.debug("Sent initial hello message with the version %s",
+                          ANKAIOS_VERSION)
+    

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -112,7 +112,7 @@ Usage
             print(f"State reached.")
 """
 
-__all__ = ["Ankaios", "AnkaiosLogLevel"]
+__all__ = ["Ankaios"]
 
 import time
 from typing import Union
@@ -195,7 +195,7 @@ class Ankaios:
         Returns:
             ControlInterfaceState: The state of the control interface.
         """
-        return self._ci.state()
+        return self._ci.state
 
     def _state_changed(self, state: ControlInterfaceState) -> None:
         """
@@ -211,7 +211,7 @@ class Ankaios:
         """
         request_id = response.get_request_id()
         self.logger.debug("Received a response with the id %s",
-                            request_id)
+                          request_id)
         with self._responses_lock:
             if request_id in self._responses:
                 self.logger.debug(

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -138,8 +138,8 @@ class Ankaios:
     and responses sent and received over the Ankaios Control Interface.
 
     Attributes:
+        state (ControlInterfaceState): The state of the control interface.
         logger (logging.Logger): The logger for the Ankaios class.
-        path (str): The path to the control interface.
     """
     DEFAULT_TIMEOUT = 5.0
     "(float): The default timeout, if not manually provided."
@@ -158,11 +158,11 @@ class Ankaios:
         self.set_logger_level(log_level)
 
         # Connect to the control interface
-        self._ci = ControlInterface(
+        self._control_interface = ControlInterface(
             add_response_callback=self._add_response,
             state_changed_callback=self._state_changed
             )
-        self._ci.connect()
+        self._control_interface.connect()
 
     def __enter__(self) -> "Ankaios":
         """
@@ -185,7 +185,7 @@ class Ankaios:
         if exc_type is not None:  # pragma: no cover
             self.logger.error("An exception occurred: %s, %s, %s",
                               exc_type, exc_value, traceback)
-        self._ci.disconnect()
+        self._control_interface.disconnect()
 
     @property
     def state(self) -> ControlInterfaceState:
@@ -195,7 +195,7 @@ class Ankaios:
         Returns:
             ControlInterfaceState: The state of the control interface.
         """
-        return self._ci.state
+        return self._control_interface.state
 
     def _state_changed(self, state: ControlInterfaceState) -> None:
         """
@@ -266,7 +266,7 @@ class Ankaios:
             TimeoutError: If the request timed out.
             AnkaiosConnectionException: If not connected.
         """
-        self._ci.write_request(request)
+        self._control_interface.write_request(request)
 
         try:
             response = self._get_response_by_id(request.get_id(), timeout)

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -138,7 +138,6 @@ class Ankaios:
     and responses sent and received over the Ankaios Control Interface.
 
     Attributes:
-        state (ControlInterfaceState): The state of the control interface.
         logger (logging.Logger): The logger for the Ankaios class.
     """
     DEFAULT_TIMEOUT = 5.0

--- a/ankaios_sdk/exceptions.py
+++ b/ankaios_sdk/exceptions.py
@@ -23,7 +23,7 @@ Exceptions
 - ConnectionClosedException: Raised when the connection is closed.
 - RequestException: Raised when the request is invalid.
 - ResponseException: Raised when the response is invalid.
-- ControlInterfaceException: Raised when an operation on the connection fails.
+- ControlInterfaceException: Raised when an operation fails.
 - AnkaiosException: Raised when an update operation fails.
 """
 

--- a/ankaios_sdk/exceptions.py
+++ b/ankaios_sdk/exceptions.py
@@ -23,7 +23,7 @@ Exceptions
 - ConnectionClosedException: Raised when the connection is closed.
 - RequestException: Raised when the request is invalid.
 - ResponseException: Raised when the response is invalid.
-- AnkaiosConnectionException: Raised when an operation on the connection fails.
+- ControlInterfaceException: Raised when an operation on the connection fails.
 - AnkaiosException: Raised when an update operation fails.
 """
 

--- a/ankaios_sdk/exceptions.py
+++ b/ankaios_sdk/exceptions.py
@@ -32,7 +32,7 @@ import inspect
 __all__ = ['WorkloadFieldException', 'WorkloadBuilderException',
            'InvalidManifestException', 'ConnectionClosedException',
            'RequestException', 'ResponseException',
-           'AnkaiosConnectionException', 'AnkaiosException']
+           'ControlInterfaceException', 'AnkaiosException']
 
 
 class AnkaiosBaseException(Exception):
@@ -67,8 +67,8 @@ class ResponseException(AnkaiosBaseException):
     """Raised when the response is invalid."""
 
 
-class AnkaiosConnectionException(AnkaiosBaseException):
-    """Raised when an operation on the connection fails."""
+class ControlInterfaceException(AnkaiosBaseException):
+    """Raised when an operation on the Control Interface fails"""
 
 
 class AnkaiosException(AnkaiosBaseException):

--- a/ankaios_sdk/utils.py
+++ b/ankaios_sdk/utils.py
@@ -34,9 +34,19 @@ import threading
 
 
 SUPPORTED_API_VERSION = "v0.1"
+"(str): The supported API version of the Ankaios SDK."
+
 ANKAIOS_VERSION = "0.5.0"
+"(str): The version of the compatible Ankaios."
+
 WORKLOADS_PREFIX = "desiredState.workloads"
+"(str): The prefix for the workloads in the desired state."
+
 CONFIGS_PREFIX = "desiredState.configs"
+"(str): The prefix for the configs in the desired state."
+
+DEFAULT_CONTROL_INTERFACE_PATH = "/run/ankaios/control_interface"
+"(str): The base path for the Ankaios control interface."
 
 
 # Used to sync across different threads when adding handlers

--- a/docs/source/control_interface.rst
+++ b/docs/source/control_interface.rst
@@ -1,0 +1,22 @@
+ControlInterface
+================
+
+.. automodule:: ankaios_sdk._components.control_interface
+
+ControlInterface Class
+----------------------
+
+.. autoclass:: ankaios_sdk._components.control_interface.ControlInterface
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ControlInterfaceState Enum
+--------------------------
+
+.. autoclass:: ankaios_sdk._components.control_interface.ControlInterfaceState
+    :special-members: __str__
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@
    manifest
    request
    response
+   control_interface
    utils
    exceptions
 

--- a/setup.py
+++ b/setup.py
@@ -107,12 +107,12 @@ setup(
         "Bug Tracker": "https://github.com/eclipse-ankaios/ank-sdk-python/issues",
     },
     install_requires=[
-        "protobuf==5.27.2",  # Protocol Buffers
+        "protobuf==5.28.1",  # Protocol Buffers
         "PyYAML",  # Used to parse manifest files
     ],
     setup_requires=[
-        "protobuf==5.27.2",  # Protocol Buffers
-        "grpcio-tools>=1.56.2",  # Needed for an OS independent protoc
+        "protobuf==5.28.1",  # Protocol Buffers
+        "grpcio-tools==1.66.1",  # Needed for an OS independent protoc
         "requests",  # Used to download the proto files
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -107,11 +107,11 @@ setup(
         "Bug Tracker": "https://github.com/eclipse-ankaios/ank-sdk-python/issues",
     },
     install_requires=[
-        "protobuf==5.28.1",  # Protocol Buffers
+        "protobuf==5.27.2",  # Protocol Buffers
         "PyYAML",  # Used to parse manifest files
     ],
     setup_requires=[
-        "protobuf==5.28.1",  # Protocol Buffers
+        "protobuf==5.27.2",  # Protocol Buffers
         "grpcio-tools==1.66.1",  # Needed for an OS independent protoc
         "requests",  # Used to download the proto files
     ],

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -45,7 +45,7 @@ def generate_test_ankaios() -> Ankaios:
     with patch("ankaios_sdk.ControlInterface.connect") as mock_connect:
         ankaios = Ankaios()
         mock_connect.assert_called_once()
-    ankaios._control_interface._state = ControlInterfaceState.CONNECTED
+    ankaios._control_interface._state = ControlInterfaceState.INITIALIZED
     return ankaios
 
 
@@ -88,7 +88,7 @@ def test_state():
     """
     ankaios = generate_test_ankaios()
     assert ankaios.state == ankaios._control_interface._state
-    ankaios._state_changed(ControlInterfaceState.DISCONNECTED)
+    ankaios._state_changed(ControlInterfaceState.TERMINATED)
 
 
 def test_add_response():

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -87,8 +87,12 @@ def test_state():
     Test the state property of the Ankaios class and the state callback.
     """
     ankaios = generate_test_ankaios()
+    ankaios.logger = MagicMock()
     assert ankaios.state == ankaios._control_interface._state
     ankaios._state_changed(ControlInterfaceState.TERMINATED)
+    ankaios.logger.info.assert_called_with(
+        "State changed to %s", ControlInterfaceState.TERMINATED
+    )
 
 
 def test_add_response():

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -17,22 +17,18 @@ This module contains unit tests for the Ankaios class in the ankaios_sdk.
 """
 
 from io import StringIO
-import time
 import logging
-import threading
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, MagicMock
 import pytest
 from ankaios_sdk import Ankaios, AnkaiosLogLevel, Response, ResponseEvent, \
     UpdateStateSuccess, Manifest, CompleteState, WorkloadInstanceName, \
-    WorkloadStateCollection, WorkloadStateEnum, AnkaiosConnectionException, \
+    WorkloadStateCollection, WorkloadStateEnum, ControlInterfaceState, \
     AnkaiosException
-from ankaios_sdk.utils import WORKLOADS_PREFIX, ANKAIOS_VERSION
-from ankaios_sdk._protos import _control_api
+from ankaios_sdk.utils import WORKLOADS_PREFIX
 from tests.workload.test_workload import generate_test_workload
 from tests.test_request import generate_test_request
 from tests.response.test_response import MESSAGE_BUFFER_ERROR, \
-    MESSAGE_BUFFER_COMPLETE_STATE, MESSAGE_UPDATE_SUCCESS, \
-    MESSAGE_BUFFER_UPDATE_SUCCESS, MESSAGE_BUFFER_UPDATE_SUCCESS_LENGTH
+    MESSAGE_BUFFER_COMPLETE_STATE, MESSAGE_BUFFER_UPDATE_SUCCESS
 from tests.test_manifest import MANIFEST_DICT
 from tests.workload_state.test_workload_state import \
     generate_test_workload_state
@@ -46,8 +42,10 @@ def generate_test_ankaios() -> Ankaios:
     Returns:
         Ankaios: The Ankaios instance.
     """
-    with patch("ankaios_sdk.Ankaios._connect"):
+    with patch("ankaios_sdk.ControlInterface.connect") as mock_connect:
         ankaios = Ankaios()
+        mock_connect.assert_called_once()
+    ankaios._ci.state = ControlInterfaceState.CONNECTED
     return ankaios
 
 
@@ -72,215 +70,47 @@ def test_logger():
 
 def test_connection():
     """
-    Test the connect / disconnect functionality of the Ankaios class.
+    Test the connect and disconnect of the Ankaios class.
     """
-    # Already connected
-    with pytest.raises(AnkaiosConnectionException,
-                       match="Already connected."):
-        ankaios = generate_test_ankaios()
-        ankaios._connected = True
-        ankaios._connect()
-
-    # Test input pipe does not exist
-    with patch("os.path.exists") as mock_exists, \
-        pytest.raises(AnkaiosConnectionException,
-                      match="Control interface input fifo"):
-        mock_exists.side_effect = lambda path: \
-            path != "/run/ankaios/control_interface/input"
-        ankaios = Ankaios()
-
-    # Test output pipe does not exist
-    with patch("os.path.exists") as mock_exists, \
-        pytest.raises(AnkaiosConnectionException,
-                      match="Control interface output fifo"):
-        mock_exists.side_effect = lambda path: \
-            path != "/run/ankaios/control_interface/output"
-        ankaios = Ankaios()
-
-    # Test output pipe error
-    with patch("os.path.exists") as mock_exists, \
-        patch("builtins.open") as mock_open_file, \
-        pytest.raises(AnkaiosConnectionException,
-                      match="Error while opening output fifo"):
-        mock_exists.return_value = True
-        mock_open_file.side_effect = OSError
-        ankaios = Ankaios()
-
-    # Test success
-    with patch("os.path.exists") as mock_exists, \
-            patch("threading.Thread") as mock_thread, \
-            patch("builtins.open") as mock_open_file, \
-            patch("ankaios_sdk.Ankaios._send_initial_hello") \
-            as mock_initial_hello:
-        mock_exists.return_value = True
-        mock_thread_instance = MagicMock()
-        mock_thread.return_value = mock_thread_instance
-        output_file_mock = MagicMock()
-        mock_open_file.return_value = output_file_mock
-
-        # Build ankaios and connect
-        ankaios = Ankaios()
-        mock_thread.assert_called_once_with(
-            target=ankaios._read_from_control_interface,
-            daemon=True
-        )
-        mock_thread_instance.start.assert_called_once()
-        mock_open_file.assert_called_once_with(
-            "/run/ankaios/control_interface/output", "ab"
-        )
-        assert ankaios._read_thread is not None
-        assert ankaios._output_file == output_file_mock
-        mock_initial_hello.assert_called_once()
-        assert ankaios._connected
-
-        # Disconnect
-        ankaios.disconnect()
-
-        mock_thread_instance.join.assert_called_once()
-        output_file_mock.close.assert_called_once()
-
-    # Test context manager
-    with patch("os.path.exists") as mock_exists, \
-            patch("threading.Thread") as mock_thread, \
-            patch("builtins.open") as mock_open_file, \
-            patch("ankaios_sdk.Ankaios._send_initial_hello") \
-            as mock_initial_hello:
-        mock_exists.return_value = True
-        mock_thread_instance = MagicMock()
-        mock_thread.return_value = mock_thread_instance
-        output_file_mock = MagicMock()
-        mock_open_file.return_value = output_file_mock
-
+    with patch("ankaios_sdk.ControlInterface.connect") as mock_ci_connect, \
+         patch("ankaios_sdk.ControlInterface.disconnect") \
+            as mock_ci_disconnect:
         with Ankaios() as ankaios:
-            mock_thread.assert_called_once_with(
-                target=ankaios._read_from_control_interface,
-                daemon=True
-            )
-            mock_thread_instance.start.assert_called_once()
-            mock_open_file.assert_called_once_with(
-                "/run/ankaios/control_interface/output", "ab"
-            )
-            assert ankaios._read_thread is not None
-            assert ankaios._output_file == output_file_mock
-            mock_initial_hello.assert_called_once()
-            assert ankaios._connected
-
-        mock_thread_instance.join.assert_called_once()
-        output_file_mock.close.assert_called_once()
-        assert not ankaios._connected
-        assert ankaios._disconnect_event.is_set()
+            assert isinstance(ankaios, Ankaios)
+            mock_ci_connect.assert_called_once()
+            assert ankaios.logger.level == AnkaiosLogLevel.INFO.value
+        mock_ci_disconnect.assert_called_once()
 
 
-def test_read_from_control_interface():
+def test_state():
     """
-    Test the _read_from_control_interface method of the Ankaios class.
+    Test the state property of the Ankaios class and the state callback.
     """
-    input_file_content = MESSAGE_BUFFER_UPDATE_SUCCESS_LENGTH + \
-        MESSAGE_BUFFER_UPDATE_SUCCESS
+    ankaios = generate_test_ankaios()
+    assert ankaios.state == ankaios._ci.state
+    ankaios._state_changed(ControlInterfaceState.DISCONNECTED)
+
+
+def test_add_response():
+    """
+    Test the _add_response method of the Ankaios class.
+    This method is called from the ControlInterface when a response
+    is received.
+    """
+    response = Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
 
     # Test response comes first
-    with patch("builtins.open", mock_open()) as mock_file, \
-            patch("os.set_blocking") as _, \
-            patch("select.select") as mock_select:
-        mock_select.return_value = ([True], [], [])
-        mock_file_handle = mock_file.return_value.__enter__.return_value
-        mock_file_handle.read.side_effect = \
-            [bytes([b]) for b in input_file_content]
-
-        ankaios = generate_test_ankaios()
-
-        # Start thread (similar to _connect)
-        ankaios._read_thread = threading.Thread(
-            target=ankaios._read_from_control_interface
-        )
-        ankaios._connected = True
-        ankaios._read_thread.start()
-        time.sleep(0.01)
-
-        # Stop thread (similar to disconnect)
-        ankaios._connected = False
-        ankaios._disconnect_event.set()
-        ankaios._read_thread.join()
-
-        mock_file.assert_called_once_with(
-            "/run/ankaios/control_interface/input", "rb")
-        assert "1234" in list(ankaios._responses)
-        assert ankaios._responses["1234"].is_set()
+    ankaios = generate_test_ankaios()
+    ankaios._add_response(response)
+    assert "1234" in list(ankaios._responses)
+    assert ankaios._responses["1234"].is_set()
 
     # Test request set first
-    with patch("builtins.open", mock_open()) as mock_file, \
-            patch("os.set_blocking") as _, \
-            patch("select.select") as mock_select:
-        mock_select.return_value = ([True], [], [])
-        mock_file_handle = mock_file.return_value.__enter__.return_value
-        mock_file_handle.read.side_effect = \
-            [bytes([b]) for b in input_file_content]
-
-        ankaios = generate_test_ankaios()
-        ankaios._responses["1234"] = ResponseEvent()
-
-        # Start thread (similar to _connect)
-        ankaios._read_thread = threading.Thread(
-            target=ankaios._read_from_control_interface
-        )
-        ankaios._connected = True
-        ankaios._read_thread.start()
-        time.sleep(0.01)
-
-        # Stop thread (similar to disconnect)
-        ankaios._connected = False
-        ankaios._disconnect_event.set()
-        ankaios._read_thread.join()
-
-        mock_file.assert_called_once_with(
-            "/run/ankaios/control_interface/input", "rb")
-        assert "1234" in list(ankaios._responses)
-        assert ankaios._responses["1234"].is_set()
-
-
-def test_write_to_pipe():
-    """
-    Test the _write_to_pipe method of the Ankaios class.
-    """
     ankaios = generate_test_ankaios()
-    with pytest.raises(AnkaiosConnectionException,
-                       match="Could not write to pipe, not connected."):
-        ankaios._write_to_pipe(None)
-
-    ankaios._connected = True
-    output_file = MagicMock()
-    ankaios._output_file = output_file
-
-    ankaios._write_to_pipe(MESSAGE_UPDATE_SUCCESS)
-
-    output_file.write.assert_called()
-    output_file.flush.assert_called_once()
-
-
-def test_write_request():
-    """
-    Test the _write_request method of the Ankaios class.
-    """
-    ankaios = generate_test_ankaios()
-    with patch("ankaios_sdk.Ankaios._write_to_pipe") as mock_write:
-        request = generate_test_request()
-        ankaios._write_request(request)
-        mock_write.assert_called_once()
-
-
-def test_send_initial_hello():
-    """
-    Test the _send_initial_hello method of the Ankaios class.
-    """
-    ankaios = generate_test_ankaios()
-    with patch("ankaios_sdk.Ankaios._write_to_pipe") as mock_write:
-        initial_hello = _control_api.ToAnkaios(
-            hello=_control_api.Hello(
-                protocolVersion=str(ANKAIOS_VERSION)
-            )
-        )
-        ankaios._send_initial_hello()
-        mock_write.assert_called_once_with(initial_hello)
+    ankaios._responses["1234"] = ResponseEvent()
+    ankaios._add_response(response)
+    assert "1234" in list(ankaios._responses)
+    assert ankaios._responses["1234"].is_set()
 
 
 def test_get_reponse_by_id():
@@ -288,13 +118,6 @@ def test_get_reponse_by_id():
     Test the get_response_by_id method of the Ankaios class.
     """
     ankaios = generate_test_ankaios()
-    with pytest.raises(
-            AnkaiosConnectionException,
-            match="Not connected."
-            ):
-        ankaios._get_response_by_id("1234")
-    ankaios._connected = True
-
     assert not ankaios._responses
     with patch("ankaios_sdk.ResponseEvent.wait_for_response") as mock_wait:
         ankaios._get_response_by_id("1234")
@@ -313,10 +136,9 @@ def test_send_request():
     Test the _send_request method of the Ankaios class.
     """
     ankaios = generate_test_ankaios()
-    ankaios._connected = True
 
     request = generate_test_request()
-    with patch("ankaios_sdk.Ankaios._write_request") as mock_write, \
+    with patch("ankaios_sdk.ControlInterface.write_request") as mock_write, \
             patch("ankaios_sdk.Ankaios._get_response_by_id") \
             as mock_get_response:
         ankaios._send_request(request)
@@ -325,7 +147,7 @@ def test_send_request():
             request.get_id(), Ankaios.DEFAULT_TIMEOUT
         )
 
-    with patch("ankaios_sdk.Ankaios._write_request") as mock_write, \
+    with patch("ankaios_sdk.ControlInterface.write_request") as mock_write, \
             patch("ankaios_sdk.Ankaios._get_response_by_id") \
             as mock_get_response:
         mock_get_response.side_effect = TimeoutError()

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -45,7 +45,7 @@ def generate_test_ankaios() -> Ankaios:
     with patch("ankaios_sdk.ControlInterface.connect") as mock_connect:
         ankaios = Ankaios()
         mock_connect.assert_called_once()
-    ankaios._ci.state = ControlInterfaceState.CONNECTED
+    ankaios._control_interface._state = ControlInterfaceState.CONNECTED
     return ankaios
 
 
@@ -87,7 +87,7 @@ def test_state():
     Test the state property of the Ankaios class and the state callback.
     """
     ankaios = generate_test_ankaios()
-    assert ankaios.state == ankaios._ci.state
+    assert ankaios.state == ankaios._control_interface._state
     ankaios._state_changed(ControlInterfaceState.DISCONNECTED)
 
 

--- a/tests/test_control_interface.py
+++ b/tests/test_control_interface.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2024 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module contains unit tests for the ControlInterface class
+in the ankaios_sdk.
+"""
+
+import threading
+import time
+from unittest.mock import patch, mock_open, MagicMock
+import pytest
+from ankaios_sdk import ControlInterface, ControlInterfaceState, \
+    ControlInterfaceException
+from ankaios_sdk.utils import ANKAIOS_VERSION
+from ankaios_sdk._protos import _control_api
+from tests.test_request import generate_test_request
+from tests.response.test_response import MESSAGE_BUFFER_UPDATE_SUCCESS, \
+    MESSAGE_BUFFER_UPDATE_SUCCESS_LENGTH
+
+
+def test_state():
+    """
+    Test the state enum and the changing of the state.
+    """
+    state_changed = MagicMock()
+    ci = ControlInterface(
+        add_response_callback=lambda _: None,
+        state_changed_callback=state_changed
+    )
+    ci.logger = MagicMock()
+    assert ci.state == ControlInterfaceState.DISCONNECTED
+    assert str(ci.state) == "DISCONNECTED"
+
+    ci.change_state(ControlInterfaceState.CONNECTED)
+    assert ci.state == ControlInterfaceState.CONNECTED
+    state_changed.assert_called_once_with(ControlInterfaceState.CONNECTED)
+
+    ci.change_state(ControlInterfaceState.CONNECTED)
+    ci.logger.debug.assert_called_with(
+        "State is already %s.", ControlInterfaceState.CONNECTED)
+
+
+def test_connection():
+    """
+    Test the connect / disconnect functionality.
+    """
+    ci = ControlInterface(
+        add_response_callback=lambda _: None,
+        state_changed_callback=lambda _: None
+    )
+    ci.state = ControlInterfaceState.CONNECTED
+
+    # Already connected
+    with pytest.raises(ControlInterfaceException,
+                       match="Already connected."):
+        ci.connect()
+
+    # Test input pipe does not exist
+    ci.state = ControlInterfaceState.DISCONNECTED
+    with patch("os.path.exists") as mock_exists, \
+        pytest.raises(ControlInterfaceException,
+                      match="Control interface input fifo"):
+        mock_exists.side_effect = lambda path: \
+            path != "/run/ankaios/control_interface/input"
+        ci.connect()
+
+    # Test output pipe does not exist
+    with patch("os.path.exists") as mock_exists, \
+        pytest.raises(ControlInterfaceException,
+                      match="Control interface output fifo"):
+        mock_exists.side_effect = lambda path: \
+            path != "/run/ankaios/control_interface/output"
+        ci.connect()
+
+    # Test output pipe error
+    with patch("os.path.exists") as mock_exists, \
+        patch("builtins.open") as mock_open_file, \
+        pytest.raises(ControlInterfaceException,
+                      match="Error while opening output fifo"):
+        mock_exists.return_value = True
+        mock_open_file.side_effect = OSError
+        ci.connect()
+
+    # Test success
+    with patch("os.path.exists") as mock_exists, \
+            patch("threading.Thread") as mock_thread, \
+            patch("builtins.open") as mock_open_file, \
+            patch("ankaios_sdk.ControlInterface._send_initial_hello") \
+            as mock_initial_hello:
+        mock_exists.return_value = True
+        mock_thread_instance = MagicMock()
+        mock_thread.return_value = mock_thread_instance
+        output_file_mock = MagicMock()
+        mock_open_file.return_value = output_file_mock
+
+        # Build ankaios and connect
+        ci.connect()
+        mock_thread.assert_called_once_with(
+            target=ci._read_from_control_interface,
+            daemon=True
+        )
+        mock_thread_instance.start.assert_called_once()
+        mock_open_file.assert_called_once_with(
+            "/run/ankaios/control_interface/output", "ab"
+        )
+        assert ci._read_thread is not None
+        assert ci._output_file == output_file_mock
+        mock_initial_hello.assert_called_once()
+        assert ci.state == ControlInterfaceState.CONNECTED
+        assert not ci._disconnect_event.is_set()
+
+        # Disconnect
+        ci.disconnect()
+
+        assert ci._disconnect_event.is_set()
+        assert ci.state == ControlInterfaceState.DISCONNECTED
+        mock_thread_instance.join.assert_called_once()
+        assert ci._read_thread is None
+        output_file_mock.close.assert_called_once()
+        assert ci._output_file is None
+
+    # Test disconnect while not connected
+    ci.logger = MagicMock()
+    assert ci.state == ControlInterfaceState.DISCONNECTED
+    ci.disconnect()
+    ci.logger.debug.assert_called_with("Already disconnected.")
+
+
+def test_read_from_control_interface():
+    """
+    Test the _read_from_control_interface method of the Ankaios class.
+    """
+    input_file_content = MESSAGE_BUFFER_UPDATE_SUCCESS_LENGTH + \
+        MESSAGE_BUFFER_UPDATE_SUCCESS
+    response_callback = MagicMock()
+
+    # Test error while opening input pipe
+    with patch("builtins.open", side_effect=OSError), \
+         patch("ankaios_sdk.ControlInterface.disconnect") as mock_disconnect:
+        ci = ControlInterface(
+            add_response_callback=response_callback,
+            state_changed_callback=lambda _: None
+        )
+        with pytest.raises(ControlInterfaceException,
+                           match="Error while opening input fifo"):
+            ci._read_from_control_interface()
+        mock_disconnect.assert_called_once()
+
+    # Test success
+    with patch("builtins.open", mock_open()) as mock_file, \
+            patch("os.set_blocking") as _, \
+            patch("select.select") as mock_select:
+        mock_select.return_value = ([True], [], [])
+        mock_file_handle = mock_file.return_value.__enter__.return_value
+        mock_file_handle.read.side_effect = \
+            [bytes([b]) for b in input_file_content]
+
+        ci = ControlInterface(
+            add_response_callback=response_callback,
+            state_changed_callback=lambda _: None
+        )
+
+        # Start thread (similar to _connect)
+        ci._read_thread = threading.Thread(
+            target=ci._read_from_control_interface,
+            daemon=True
+        )
+        ci.state = ControlInterfaceState.CONNECTED
+        ci._read_thread.start()
+        time.sleep(0.01)
+
+        # Stop thread (similar to disconnect)
+        ci.state = ControlInterfaceState.DISCONNECTED
+        ci._disconnect_event.set()
+        ci._read_thread.join()
+
+        mock_file.assert_called_once_with(
+            "/run/ankaios/control_interface/input", "rb")
+        response_callback.assert_called_once()
+
+
+def test_write_to_pipe():
+    """
+    Test the _write_to_pipe method of the ControlInterface class.
+    """
+    ci = ControlInterface(
+        add_response_callback=lambda _: None,
+        state_changed_callback=lambda _: None
+        )
+
+    ci._output_file = None
+    with pytest.raises(ControlInterfaceException,
+                       match="Could not write to pipe"):
+        ci._write_to_pipe(_control_api.FromAnkaios())
+
+    output_file = MagicMock()
+    ci._output_file = output_file
+
+    ci._write_to_pipe(_control_api.FromAnkaios())
+
+    output_file.write.assert_called()
+    output_file.flush.assert_called_once()
+
+
+def test_write_request():
+    """
+    Test the write_request method of the ControlInterface class.
+    """
+    ci = ControlInterface(
+        add_response_callback=lambda _: None,
+        state_changed_callback=lambda _: None
+        )
+
+    ci.state = ControlInterfaceState.DISCONNECTED
+    with pytest.raises(ControlInterfaceException,
+                       match="Could not write to pipe"):
+        ci.write_request(generate_test_request())
+
+    ci.state = ControlInterfaceState.CONNECTED
+    with patch("ankaios_sdk.ControlInterface._write_to_pipe") as mock_write:
+        ci.write_request(generate_test_request())
+        mock_write.assert_called_once()
+
+
+def test_send_initial_hello():
+    """
+    Test the _send_initial_hello method of the Ankaios class.
+    """
+    ci = ControlInterface(
+        add_response_callback=lambda _: None,
+        state_changed_callback=lambda _: None
+        )
+    with patch("ankaios_sdk.ControlInterface._write_to_pipe") as mock_write:
+        initial_hello = _control_api.ToAnkaios(
+            hello=_control_api.Hello(
+                protocolVersion=str(ANKAIOS_VERSION)
+            )
+        )
+        ci._send_initial_hello()
+        mock_write.assert_called_once_with(initial_hello)


### PR DESCRIPTION
This PR splits the main Ankaios class into 2: `Ankaios` and `Control Interface`.
With this, a `ControlInterfaceState` was added that can be used in the future.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
