### PR TITLE
Fix agent reconnect does not work

### DIFF
--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -53,7 +53,6 @@ import os
 import select
 import time
 import threading
-import signal
 from typing import Callable
 from enum import Enum
 from google.protobuf.internal.encoder import _VarintBytes
@@ -64,12 +63,6 @@ from .request import Request
 from .response import Response, ResponseException
 from ..exceptions import ControlInterfaceException, ConnectionClosedException
 from ..utils import DEFAULT_CONTROL_INTERFACE_PATH, get_logger, ANKAIOS_VERSION
-
-
-# Used to redirect the SIGPIPE signal to the SIG_IGN handler.
-# This is done to prevent the program from crashing when
-# writing to a closed pipe.
-signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
 
 class ControlInterfaceState(Enum):

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -280,9 +280,8 @@ class ControlInterface:
                 if not varint_buffer:
                     self.change_state(
                         ControlInterfaceState.AGENT_DISCONNECTED)
-                    self._logger.error(
-                        "Nothing to read from the input fifo pipe. "
-                        "Is the agent still there?"
+                    self._logger.warning(
+                        "Nothing to read from the input fifo pipe."
                         )
                     self._agent_gone_routine()
                     continue
@@ -322,14 +321,15 @@ class ControlInterface:
         It will attempt to write the hello message to the agent
         until the agent is connected.
         """
+        agent_check_interval = 1  # seconds
         while self.state == ControlInterfaceState.AGENT_DISCONNECTED:
             try:
                 self._send_initial_hello()
             except BrokenPipeError as _:
-                self._logger.error(
+                self._logger.warning(
                     "Waiting for the agent.."
                     )
-                time.sleep(1)
+                time.sleep(agent_check_interval)
             else:
                 self.change_state(ControlInterfaceState.INITIALIZED)
                 break

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -321,7 +321,7 @@ class ControlInterface:
         It will attempt to write the hello message to the agent
         until the agent is connected.
         """
-        agent_check_interval = 1  # seconds
+        AGENT_RECONNECT_INTERVAL = 1  # seconds
         while self.state == ControlInterfaceState.AGENT_DISCONNECTED:
             try:
                 self._send_initial_hello()
@@ -329,7 +329,7 @@ class ControlInterface:
                 self._logger.warning(
                     "Waiting for the agent.."
                     )
-                time.sleep(agent_check_interval)
+                time.sleep(AGENT_RECONNECT_INTERVAL)
             else:
                 self.change_state(ControlInterfaceState.INITIALIZED)
                 break

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -333,7 +333,7 @@ class ControlInterface:
             try:
                 self._send_initial_hello()
             except BrokenPipeError as _:
-                self.logger.error(
+                self._logger.error(
                     "Waiting for the agent.."
                     )
                 time.sleep(1)


### PR DESCRIPTION
Issues: https://github.com/eclipse-ankaios/ank-sdk-python/issues/39

# Solution

When the agent gets disconnected, the sdk enters a routine where it tries to send the `hello` message over and over. Succeeding in sending it means the agent is back. The agent will receive a number of `hello` messages when starting, but this is ok because the first one will be taken into account (and much needed by the whole interaction) and the rest of them will be ignored, thus the communication can continue.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
