### PR TITLE
Fix duplicate control interface path declaration

### DIFF
--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -96,7 +96,7 @@ class ControlInterface:
     Attributes:
         path (str): The path to the control interface.
     """
-    ANKAIOS_CONTROL_INTERFACE_BASE_PATH = "/run/ankaios/control_interface"
+    ANKAIOS_CONTROL_INTERFACE_BASE_PATH = DEFAULT_CONTROL_INTERFACE_PATH
     "(str): The base path for the Ankaios control interface."
 
     def __init__(self,
@@ -113,7 +113,6 @@ class ControlInterface:
             state_changed_callback (Callable): The callback function to
                 to call when the state of the control interface changes.
         """
-        self.path = DEFAULT_CONTROL_INTERFACE_PATH
         self._input_file = None
         self._output_file = None
         # The state of the control interface must not be changed directly.

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -92,9 +92,6 @@ class ControlInterface:
     This class handles the interaction with the Ankaios control interface.
     It provides methods to send and receive data to and from the control
     interface pipes.
-
-    Attributes:
-        path (str): The path to the control interface.
     """
     ANKAIOS_CONTROL_INTERFACE_BASE_PATH = DEFAULT_CONTROL_INTERFACE_PATH
     "(str): The base path for the Ankaios control interface."


### PR DESCRIPTION
# Issue

The control interface path was declared twice: once in utils.py and once in control_interface.py, in the Ankaios class. This PR solves this duplicate declaration.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
