### PR TITLE
Final changes before the 0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ![Build](https://github.com/eclipse-ankaios/ank-sdk-python/actions/workflows/build.yml/badge.svg?job=build)
 ![PyPI - Version](https://img.shields.io/pypi/v/ankaios_sdk)
 ![Python](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)
-![OS](https://img.shields.io/badge/os-independent-lightgrey)
 
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 [![Ankaios](https://img.shields.io/badge/main_project-repo-blue)](https://github.com/eclipse-ankaios/ankaios)

--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -143,7 +143,7 @@ class ControlInterface:
         from the input fifo and opening the output fifo.
 
         Raises:
-            AnkaiosConnectionException: If an error occurred.
+            ControlInterfaceException: If an error occurred.
         """
         if self._state == ControlInterfaceState.INITIALIZED:
             raise ControlInterfaceException("Already connected.")
@@ -233,7 +233,7 @@ class ControlInterface:
         The responses are then sent to the Ankaios class to be handled.
 
         Raises:
-            AnkaiosConnectionException: If an error occurs
+            ControlInterfaceException: If an error occurs
                 while reading the fifo.
         """
         # The pragma: no cover is used on small checks that are not expected
@@ -343,7 +343,7 @@ class ControlInterface:
             to_ankaios (_control_api.ToAnkaios): The ToAnkaios proto message.
 
         Raises:
-            AnkaiosConnectionException: If the output pipe is None.
+            ControlInterfaceException: If the output pipe is None.
         """
         if self._output_file is None:
             self._logger.error(
@@ -367,7 +367,7 @@ class ControlInterface:
             request (Request): The request object to be written.
 
         Raises:
-            AnkaiosConnectionException: If not connected.
+            ControlInterfaceException: If not connected.
         """
         if not self._state == ControlInterfaceState.INITIALIZED:
             raise ControlInterfaceException(
@@ -384,7 +384,7 @@ class ControlInterface:
         to the control interface.
 
         Raises:
-            AnkaiosConnectionException: If an error occurred.
+            ControlInterfaceException: If not connected.
         """
         initial_hello = _control_api.ToAnkaios(
             hello=_control_api.Hello(

--- a/ankaios_sdk/_components/response.py
+++ b/ankaios_sdk/_components/response.py
@@ -170,18 +170,6 @@ class Response:
         """
         return self._response.requestId
 
-    def check_request_id(self, request_id: str) -> bool:
-        """
-        Checks if the request id of the response matches the given request id.
-
-        Args:
-            request_id (str): The request id to check against.
-
-        Returns:
-            bool: True if the request_id matches, False otherwise.
-        """
-        return self._response.requestId == request_id
-
     def get_content(self) -> \
             tuple[
                 'ResponseType',

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -118,7 +118,7 @@ import time
 from typing import Union
 import threading
 
-from .exceptions import AnkaiosException
+from .exceptions import AnkaiosUpdateException
 from ._components import Workload, CompleteState, Request, RequestType, \
                          Response, ResponseType, UpdateStateSuccess, \
                          ResponseEvent, WorkloadStateCollection, Manifest, \
@@ -316,7 +316,7 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to apply manifest: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
@@ -325,7 +325,7 @@ class Ankaios:
                 len(content.deleted_workloads)
             )
             return content
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def delete_manifest(self, manifest: Manifest,
                         timeout: float = DEFAULT_TIMEOUT
@@ -361,7 +361,7 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete manifest: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
@@ -370,7 +370,7 @@ class Ankaios:
                 len(content.deleted_workloads)
             )
             return content
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def apply_workload(self, workload: Workload,
                        timeout: float = DEFAULT_TIMEOUT
@@ -409,7 +409,7 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to run workload: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
@@ -418,7 +418,7 @@ class Ankaios:
                 len(content.deleted_workloads)
             )
             return content
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def get_workload(self, workload_name: str,
                      timeout: float = DEFAULT_TIMEOUT) -> Workload:
@@ -470,7 +470,7 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete workload: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info(
                 "Update successful: %s added workloads, "
@@ -479,7 +479,7 @@ class Ankaios:
                 len(content.deleted_workloads)
             )
             return content
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def update_configs(self, configs: dict,
                        timeout: float = DEFAULT_TIMEOUT):
@@ -512,11 +512,11 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to set the configs: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def add_config(self, name: str, config: Union[dict, list, str],
                    timeout: float = DEFAULT_TIMEOUT):
@@ -551,11 +551,11 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to add the config: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def get_configs(self,
                     timeout: float = DEFAULT_TIMEOUT) -> dict:
@@ -605,11 +605,11 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete all configs: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def delete_config(self, name: str, timeout: float = DEFAULT_TIMEOUT):
         """
@@ -638,11 +638,11 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to delete all configs: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:
             self.logger.info("Update successful")
             return
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def get_state(self, field_masks: list[str] = None,
                   timeout: float = DEFAULT_TIMEOUT, ) -> CompleteState:
@@ -676,10 +676,10 @@ class Ankaios:
         if content_type == ResponseType.ERROR:
             self.logger.error("Error while trying to get the state: %s",
                               content)
-            raise AnkaiosException(f"Received error: {content}")
+            raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.COMPLETE_STATE:
             return content
-        raise AnkaiosException("Received unexpected content type.")
+        raise AnkaiosUpdateException("Received unexpected content type.")
 
     def get_agents(
             self, timeout: float = DEFAULT_TIMEOUT
@@ -739,7 +739,7 @@ class Ankaios:
             self.logger.error("Expected exactly one workload state "
                               + "for instance name %s, but got %s",
                               instance_name, len(workload_states))
-            raise AnkaiosException(
+            raise AnkaiosUpdateException(
                 "Expected exactly one workload state for instance name "
                 + f"{instance_name}, but got {len(workload_states)}")
         return workload_states[0].execution_state

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -636,7 +636,7 @@ class Ankaios:
         # Interpret response
         (content_type, content) = response.get_content()
         if content_type == ResponseType.ERROR:
-            self.logger.error("Error while trying to delete all configs: %s",
+            self.logger.error("Error while trying to delete config: %s",
                               content)
             raise AnkaiosUpdateException(f"Received error: {content}")
         if content_type == ResponseType.UPDATE_STATE_SUCCESS:

--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -435,7 +435,7 @@ class Ankaios:
             Workload: The workload object.
         """
         return self.get_state(
-            timeout, [f"{WORKLOADS_PREFIX}.{workload_name}"]
+            [f"{WORKLOADS_PREFIX}.{workload_name}"], timeout
         ).get_workloads()[0]
 
     def delete_workload(self, workload_name: str,
@@ -566,7 +566,7 @@ class Ankaios:
             dict: The configs dictionary.
         """
         return self.get_state(
-            timeout, field_masks=[CONFIGS_PREFIX]).get_configs()
+            field_masks=[CONFIGS_PREFIX]).get_configs(), timeout
 
     def get_config(self, name: str,
                    timeout: float = DEFAULT_TIMEOUT) -> dict:
@@ -580,7 +580,7 @@ class Ankaios:
             dict: The config in a dict format.
         """
         return self.get_state(
-            timeout, field_masks=[f"{CONFIGS_PREFIX}.{name}"]).get_configs()
+            field_masks=[f"{CONFIGS_PREFIX}.{name}"]).get_configs(), timeout
 
     def delete_all_configs(self, timeout: float = DEFAULT_TIMEOUT):
         """
@@ -644,16 +644,16 @@ class Ankaios:
             return
         raise AnkaiosException("Received unexpected content type.")
 
-    def get_state(self, timeout: float = DEFAULT_TIMEOUT,
-                  field_masks: list[str] = None) -> CompleteState:
+    def get_state(self, field_masks: list[str] = None,
+                  timeout: float = DEFAULT_TIMEOUT, ) -> CompleteState:
         """
         Send a request to get the complete state.
 
         Args:
-            timeout (float): The maximum time to wait for the response,
-                in seconds.
             field_masks (list[str]): The list of field masks to filter
                 the state.
+            timeout (float): The maximum time to wait for the response,
+                in seconds.
 
         Returns:
             CompleteState: The complete state object.
@@ -694,7 +694,7 @@ class Ankaios:
         Returns:
             dict: The agents dictionary.
         """
-        return self.get_state(timeout).get_agents()
+        return self.get_state(None, timeout).get_agents()
 
     def get_workload_states(self,
                             timeout: float = DEFAULT_TIMEOUT
@@ -709,7 +709,7 @@ class Ankaios:
         Returns:
             WorkloadStateCollection: The collection of workload states.
         """
-        return self.get_state(timeout).get_workload_states()
+        return self.get_state(None, timeout).get_workload_states()
 
     def get_execution_state_for_instance_name(
             self,
@@ -733,7 +733,7 @@ class Ankaios:
             AnkaiosException: If the workload state was not
                 retrieved successfully.
         """
-        state = self.get_state(timeout, [instance_name.get_filter_mask()])
+        state = self.get_state([instance_name.get_filter_mask()], timeout)
         workload_states = state.get_workload_states().get_as_list()
         if len(workload_states) != 1:
             self.logger.error("Expected exactly one workload state "
@@ -759,7 +759,7 @@ class Ankaios:
         Returns:
             WorkloadStateCollection: The collection of workload states.
         """
-        state = self.get_state(timeout, ["workloadStates." + agent_name])
+        state = self.get_state(["workloadStates." + agent_name], timeout)
         return state.get_workload_states()
 
     def get_workload_states_for_name(self, workload_name: str,
@@ -778,7 +778,7 @@ class Ankaios:
             WorkloadStateCollection: The collection of workload states.
         """
         state = self.get_state(
-            timeout, ["workloadStates"]
+            ["workloadStates"], timeout
         )
         workload_states = state.get_workload_states().get_as_list()
         workload_states_for_name = WorkloadStateCollection()

--- a/ankaios_sdk/exceptions.py
+++ b/ankaios_sdk/exceptions.py
@@ -15,8 +15,11 @@
 """
 This script defines the exceptions used in the ankaios_sdk module.
 
+All the exceptions are derived from the AnkaiosException class.
+
 Exceptions
 ----------
+- AnkaiosException: Base exception.
 - WorkloadFieldException: Raised when the workload field is invalid.
 - WorkloadBuilderException: Raised when the workload builder is invalid.
 - InvalidManifestException: Raised when the manifest file is invalid.
@@ -24,22 +27,23 @@ Exceptions
 - RequestException: Raised when the request is invalid.
 - ResponseException: Raised when the response is invalid.
 - ControlInterfaceException: Raised when an operation fails.
-- AnkaiosException: Raised when an update operation fails.
+- AnkaiosUpdateException: Raised when an update operation fails.
 """
 
 import inspect
 
-__all__ = ['WorkloadFieldException', 'WorkloadBuilderException',
-           'InvalidManifestException', 'ConnectionClosedException',
-           'RequestException', 'ResponseException',
-           'ControlInterfaceException', 'AnkaiosException']
+__all__ = ['AnkaiosException', 'WorkloadFieldException',
+           'WorkloadBuilderException', 'InvalidManifestException',
+           'ConnectionClosedException', 'RequestException',
+           'ResponseException', 'ControlInterfaceException',
+           'AnkaiosUpdateException']
 
 
-class AnkaiosBaseException(Exception):
+class AnkaiosException(Exception):
     """Base class for exceptions in this module."""
 
 
-class WorkloadFieldException(AnkaiosBaseException):
+class WorkloadFieldException(AnkaiosException):
     """Raised when the workload field is invalid"""
     def __init__(self, field: str, value: str, accepted_values: list) -> None:
         message = f"Invalid value for {field}: \"{value}\"."
@@ -47,31 +51,31 @@ class WorkloadFieldException(AnkaiosBaseException):
         super().__init__(message)
 
 
-class WorkloadBuilderException(AnkaiosBaseException):
+class WorkloadBuilderException(AnkaiosException):
     """Raised when the workload builder is invalid."""
 
 
-class InvalidManifestException(AnkaiosBaseException):
+class InvalidManifestException(AnkaiosException):
     """Raised when the manifest file is invalid."""
 
 
-class ConnectionClosedException(AnkaiosBaseException):
+class ConnectionClosedException(AnkaiosException):
     """Raised when the connection is closed."""
 
 
-class RequestException(AnkaiosBaseException):
+class RequestException(AnkaiosException):
     """Raised when the request is invalid."""
 
 
-class ResponseException(AnkaiosBaseException):
+class ResponseException(AnkaiosException):
     """Raised when the response is invalid."""
 
 
-class ControlInterfaceException(AnkaiosBaseException):
+class ControlInterfaceException(AnkaiosException):
     """Raised when an operation on the Control Interface fails"""
 
 
-class AnkaiosException(AnkaiosBaseException):
+class AnkaiosUpdateException(AnkaiosException):
     """Raised when an update operation fails."""
     def __init__(self, message):
         function_name = inspect.stack()[1].function

--- a/ankaios_sdk/exceptions.py
+++ b/ankaios_sdk/exceptions.py
@@ -27,7 +27,8 @@ Exceptions
 - RequestException: Raised when the request is invalid.
 - ResponseException: Raised when the response is invalid.
 - ControlInterfaceException: Raised when an operation fails.
-- AnkaiosUpdateException: Raised when an update operation fails.
+- AnkaiosProtocolException: Raised when something unexpected is received.
+- AnkaiosResponseError: Raised when the response from Ankaios is an error.
 """
 
 import inspect
@@ -36,7 +37,7 @@ __all__ = ['AnkaiosException', 'WorkloadFieldException',
            'WorkloadBuilderException', 'InvalidManifestException',
            'ConnectionClosedException', 'RequestException',
            'ResponseException', 'ControlInterfaceException',
-           'AnkaiosUpdateException']
+           'AnkaiosProtocolException', 'AnkaiosResponseError']
 
 
 class AnkaiosException(Exception):
@@ -75,8 +76,12 @@ class ControlInterfaceException(AnkaiosException):
     """Raised when an operation on the Control Interface fails"""
 
 
-class AnkaiosUpdateException(AnkaiosException):
-    """Raised when an update operation fails."""
+class AnkaiosProtocolException(AnkaiosException):
+    """Raised when something unexpected is received"""
     def __init__(self, message):
         function_name = inspect.stack()[1].function
         super().__init__(f"{function_name}: {message}")
+
+
+class AnkaiosResponseError(AnkaiosException):
+    """Raised when the response from Ankaios is an error"""

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     include_package_data=True,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
+        "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/response/test_response.py
+++ b/tests/response/test_response.py
@@ -124,11 +124,3 @@ def test_getters():
     assert str(content_type) == "error"
     assert content == "Test error message"
 
-
-def test_check_request_id():
-    """
-    Test the check_request_id method of the Response class.
-    """
-    response = Response(MESSAGE_BUFFER_ERROR)
-    assert response.check_request_id("1234")
-    assert not response.check_request_id("4321")

--- a/tests/response/test_response.py
+++ b/tests/response/test_response.py
@@ -123,4 +123,3 @@ def test_getters():
     assert content_type == ResponseType.ERROR
     assert str(content_type) == "error"
     assert content == "Test error message"
-

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -23,7 +23,7 @@ import pytest
 from ankaios_sdk import Ankaios, AnkaiosLogLevel, Response, ResponseEvent, \
     UpdateStateSuccess, Manifest, CompleteState, WorkloadInstanceName, \
     WorkloadStateCollection, WorkloadStateEnum, ControlInterfaceState, \
-    AnkaiosException
+    AnkaiosUpdateException
 from ankaios_sdk.utils import WORKLOADS_PREFIX
 from tests.workload.test_workload import generate_test_workload
 from tests.test_request import generate_test_request
@@ -180,7 +180,7 @@ def test_apply_manifest():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.apply_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -197,7 +197,7 @@ def test_apply_manifest():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.apply_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -223,7 +223,7 @@ def test_delete_manifest():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -240,7 +240,7 @@ def test_delete_manifest():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -266,7 +266,7 @@ def test_apply_workload():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.apply_workload(workload)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -283,7 +283,7 @@ def test_apply_workload():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.apply_workload(workload)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -332,7 +332,7 @@ def test_delete_workload():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_workload("nginx")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -349,7 +349,7 @@ def test_delete_workload():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_workload("nginx")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -373,7 +373,7 @@ def test_update_configs():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.update_configs({"name": "config"})
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -390,7 +390,7 @@ def test_update_configs():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.update_configs({"name": "config"})
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -414,7 +414,7 @@ def test_add_config():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.add_config("name", "config")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -431,7 +431,7 @@ def test_add_config():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.add_config("name", "config")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -489,7 +489,7 @@ def test_delete_all_configs():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_all_configs()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -506,7 +506,7 @@ def test_delete_all_configs():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_all_configs()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -530,7 +530,7 @@ def test_delete_config():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_config("config_name")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -547,7 +547,7 @@ def test_delete_config():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.delete_config("config_name")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -571,7 +571,7 @@ def test_get_state():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.get_state(field_masks=["invalid_mask"])
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -588,7 +588,7 @@ def test_get_state():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.get_state()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -645,7 +645,7 @@ def test_get_execution_state_for_instance_name():
             patch("ankaios_sdk.CompleteState.get_workload_states") \
             as mock_state_get_workload_states:
         mock_get_state.return_value = CompleteState()
-        with pytest.raises(AnkaiosException):
+        with pytest.raises(AnkaiosUpdateException):
             ankaios.get_execution_state_for_instance_name(
                 workload_instance_name)
         mock_state_get_workload_states.assert_called_once()

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -23,7 +23,7 @@ import pytest
 from ankaios_sdk import Ankaios, AnkaiosLogLevel, Response, ResponseEvent, \
     UpdateStateSuccess, Manifest, CompleteState, WorkloadInstanceName, \
     WorkloadStateCollection, WorkloadStateEnum, ControlInterfaceState, \
-    AnkaiosUpdateException
+    AnkaiosProtocolException, AnkaiosResponseError
 from ankaios_sdk.utils import WORKLOADS_PREFIX
 from tests.workload.test_workload import generate_test_workload
 from tests.test_request import generate_test_request
@@ -180,7 +180,7 @@ def test_apply_manifest():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.apply_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -197,7 +197,7 @@ def test_apply_manifest():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.apply_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -223,7 +223,7 @@ def test_delete_manifest():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.delete_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -240,7 +240,7 @@ def test_delete_manifest():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.delete_manifest(manifest)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -266,7 +266,7 @@ def test_apply_workload():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.apply_workload(workload)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -283,7 +283,7 @@ def test_apply_workload():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.apply_workload(workload)
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -332,7 +332,7 @@ def test_delete_workload():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.delete_workload("nginx")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -349,7 +349,7 @@ def test_delete_workload():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.delete_workload("nginx")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -373,7 +373,7 @@ def test_update_configs():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.update_configs({"name": "config"})
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -390,7 +390,7 @@ def test_update_configs():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.update_configs({"name": "config"})
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -414,7 +414,7 @@ def test_add_config():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.add_config("name", "config")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -431,7 +431,7 @@ def test_add_config():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.add_config("name", "config")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -489,7 +489,7 @@ def test_delete_all_configs():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.delete_all_configs()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -506,7 +506,7 @@ def test_delete_all_configs():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.delete_all_configs()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -530,7 +530,7 @@ def test_delete_config():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.delete_config("config_name")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -547,7 +547,7 @@ def test_delete_config():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_COMPLETE_STATE)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.delete_config("config_name")
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -571,7 +571,7 @@ def test_get_state():
     # Test error
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = Response(MESSAGE_BUFFER_ERROR)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosResponseError):
             ankaios.get_state(field_masks=["invalid_mask"])
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -588,7 +588,7 @@ def test_get_state():
     with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
         mock_send_request.return_value = \
             Response(MESSAGE_BUFFER_UPDATE_SUCCESS)
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.get_state()
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
@@ -645,7 +645,7 @@ def test_get_execution_state_for_instance_name():
             patch("ankaios_sdk.CompleteState.get_workload_states") \
             as mock_state_get_workload_states:
         mock_get_state.return_value = CompleteState()
-        with pytest.raises(AnkaiosUpdateException):
+        with pytest.raises(AnkaiosProtocolException):
             ankaios.get_execution_state_for_instance_name(
                 workload_instance_name)
         mock_state_get_workload_states.assert_called_once()

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -307,8 +307,8 @@ def test_get_workload():
         ret = ankaios.get_workload(workload_name)
         assert ret == workload
         mock_get_state.assert_called_once_with(
-            Ankaios.DEFAULT_TIMEOUT,
-            [f"{WORKLOADS_PREFIX}.nginx"]
+            [f"{WORKLOADS_PREFIX}.nginx"],
+            Ankaios.DEFAULT_TIMEOUT
         )
         mock_state_get_workloads.assert_called_once()
 
@@ -449,7 +449,7 @@ def test_get_configs():
         mock_get_state.return_value = CompleteState()
         ankaios.get_configs()
         mock_get_state.assert_called_once_with(
-            Ankaios.DEFAULT_TIMEOUT, field_masks=['desiredState.configs']
+            field_masks=['desiredState.configs']
             )
         mock_state_get_configs.assert_called_once()
 
@@ -466,8 +466,7 @@ def test_get_config():
         mock_get_state.return_value = CompleteState()
         ankaios.get_config("config_name")
         mock_get_state.assert_called_once_with(
-            Ankaios.DEFAULT_TIMEOUT,
-            field_masks=['desiredState.configs.config_name']
+                field_masks=['desiredState.configs.config_name']
             )
         mock_state_get_configs.assert_called_once()
 
@@ -606,7 +605,9 @@ def test_get_agents():
             as mock_state_get_agents:
         mock_get_state.return_value = CompleteState()
         ankaios.get_agents()
-        mock_get_state.assert_called_once_with(Ankaios.DEFAULT_TIMEOUT)
+        mock_get_state.assert_called_once_with(
+            None, Ankaios.DEFAULT_TIMEOUT
+            )
         mock_state_get_agents.assert_called_once()
 
 
@@ -621,7 +622,9 @@ def test_get_workload_states():
             as mock_state_get_workload_states:
         mock_get_state.return_value = CompleteState()
         ankaios.get_workload_states()
-        mock_get_state.assert_called_once_with(Ankaios.DEFAULT_TIMEOUT)
+        mock_get_state.assert_called_once_with(
+            None, Ankaios.DEFAULT_TIMEOUT
+            )
         mock_state_get_workload_states.assert_called_once()
 
 
@@ -676,7 +679,8 @@ def test_get_workload_states_on_agent():
         mock_get_state.return_value = CompleteState()
         ankaios.get_workload_states_on_agent("agent_A")
         mock_get_state.assert_called_once_with(
-            Ankaios.DEFAULT_TIMEOUT, ["workloadStates.agent_A"]
+            ["workloadStates.agent_A"],
+            Ankaios.DEFAULT_TIMEOUT
         )
         mock_state_get_workload_states.assert_called_once()
 


### PR DESCRIPTION
Issues:
- `Ankaios.get_state()` should have the timeout argument as it's last;
- https://github.com/eclipse-ankaios/ank-sdk-python/issues/47;
- Remove `Response.check_request_id` method that is not used. The getter for the id is used instead and the comparison is done outside.
- Fix platform: SDK is compatible only with Linux systems for the time being.

- [x] READY TO MERGE

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
