### PR TITLE
fix: fixed stop_example.sh now contaier get filtered before stopping

### DIFF
--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -76,7 +76,7 @@ if pgrep -x "ank-server" >/dev/null
 then
   echo -e "\nAbort startup. Ankaios server is already running."
   echo "Shutdown the Ankaios server instance manually or"
-  echo -e "if 'run_example.sh' was executed previously,\nexecute 'shutdown_example.sh' afterwards to stop the example."
+  echo -e "if 'run_example.sh' was executed previously,\nexecute 'stop_example.sh' afterwards to stop the example."
   exit 3
 fi
 

--- a/examples/stop_example.sh
+++ b/examples/stop_example.sh
@@ -8,6 +8,6 @@ echo "OK."
 
 # Cleanup podman
 echo "Cleaning up podman..."
-podman stop -a >/dev/null 2>&1
-podman rm -a >/dev/null 2>&1
+podman ps -q --filter ancestor="localhost/app:0.1" | xargs -r podman stop >/dev/null 2>&1
+podman ps -q --filter ancestor="localhost/app:0.1" | xargs -r podman rm >/dev/null 2>&1
 echo "OK."


### PR DESCRIPTION
Issues: #67

<!--  Description of the change in case no issue is mentioned -->
Now example containers get filtered and if the tag equals the localhost/app:0.1 that is given in the run_example.sh it gets stopped and removed
# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [X] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
