### PR TITLE
Add step to fail the job if check failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
           pip install .[dev]
 
       - name: Run unit tests
+        id: check
         run: python3 run_checks.py --utest
         continue-on-error: true
 
@@ -64,6 +65,10 @@ jobs:
         with:
           name: unit-test-report
           path: reports/utest
+
+      - name: Fail job if check failed
+        if: steps.check.outcome != 'success'
+        run: exit 1
 
   coverage:
     needs: setup
@@ -83,6 +88,7 @@ jobs:
           pip install .[dev]
 
       - name: Run coverage
+        id: check
         run: python3 run_checks.py --cov
         continue-on-error: true
 
@@ -91,6 +97,10 @@ jobs:
         with:
           name: coverage-report
           path: reports/coverage
+
+      - name: Fail job if check failed
+        if: steps.check.outcome != 'success'
+        run: exit 1
 
   lint:
     needs: setup
@@ -110,6 +120,7 @@ jobs:
           pip install .[dev]
 
       - name: Run lint
+        id: check
         run: python3 run_checks.py --lint
         continue-on-error: true
 
@@ -118,6 +129,10 @@ jobs:
         with:
           name: pylint-report
           path: reports/pylint
+
+      - name: Fail job if check failed
+        if: steps.check.outcome != 'success'
+        run: exit 1
 
   codestyle:
     needs: setup
@@ -137,6 +152,7 @@ jobs:
           pip install .[dev]
 
       - name: Run pep8 codestyle check
+        id: check
         run: python3 run_checks.py --pep8
         continue-on-error: true
 
@@ -145,6 +161,10 @@ jobs:
         with:
           name: codestyle-report
           path: reports/codestyle
+
+      - name: Fail job if check failed
+        if: steps.check.outcome != 'success'
+        run: exit 1
 
   check_docs:
     needs: setup

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -99,6 +99,12 @@ def test_connection():
         mock_get_state.assert_called_once()
 
     with patch("ankaios_sdk.ControlInterface.connect") as _, \
+         patch("ankaios_sdk.Ankaios.get_state") as mock_get_state:
+        mock_get_state.side_effect = AnkaiosProtocolException("")
+        _ = Ankaios()
+        mock_get_state.assert_called_once()
+
+    with patch("ankaios_sdk.ControlInterface.connect") as _, \
          patch("ankaios_sdk.Ankaios.get_state") as mock_get_state, \
          pytest.raises(ConnectionClosedException):
         mock_get_state.side_effect = ConnectionClosedException()


### PR DESCRIPTION
# Issue

When the checks fail, the jobs are not failed and from outside it seems that the checks actually passed.

Example: https://github.com/eclipse-ankaios/ank-sdk-python/actions/runs/15875652628/job/44762532441?pr=76

Looking at the `Run Lint` job, it seems as it passed, but opening the details, it actually failed.

# Solution

If the job fails, because of the `continue-on-error: true` is set, the failure is ignored and the workflow passes. This PR adds an additional check after the reports are uploaded, to fail the job. In this way, the report is present after the job fails.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
