### PR TITLE
Change priority of startup log message

### DIFF
--- a/ankaios_sdk/_components/control_interface.py
+++ b/ankaios_sdk/_components/control_interface.py
@@ -252,7 +252,7 @@ class ControlInterface:
         os.set_blocking(self._input_file.fileno(), False)
 
         try:
-            self._logger.info("Started reading from the input pipe.")
+            self._logger.debug("Started reading from the input pipe.")
             while not self._disconnect_event.is_set():
                 # The loop continues when data is available or when the
                 # timeout of 1 second is reached.


### PR DESCRIPTION
Issues: -

<!--  Description of the change in case no issue is mentioned -->
When using the SDK, a INFO level logging message appears stating "Started reading from the input pipe". This has now been changed to a DEBUG level, according to its real priority.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
