### PR TITLE
Fix the release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,9 @@ jobs:
 
   docs:
     needs: release
+    permissions:
+      pages: write
+      id-token: write
     uses: ./.github/workflows/documentation.yml
 
   publish:


### PR DESCRIPTION
Add write permissions to the documentation workflow in the release.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
