### PR TITLE
Publish documentation only after wheel has being published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,13 +89,6 @@ jobs:
         reports/pylint-report.zip \
         reports/codestyle-report.zip
 
-  docs:
-    needs: release
-    permissions:
-      pages: write
-      id-token: write
-    uses: ./.github/workflows/documentation.yml
-
   publish:
     needs: release
     environment:
@@ -116,3 +109,10 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         attestations: true
+
+  docs:
+    needs: publish
+    permissions:
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/documentation.yml


### PR DESCRIPTION
To avoid situations in which the documentation has being published, but the wheel publishing fails, we should only publish the doc once the wheel is available.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
