### PR TITLE
Weekly job creates gh issue on new python version

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,10 +14,14 @@ jobs:
 
   check-python-version:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for new Python versions
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           latest=$(curl -s https://endoflife.date/api/python.json | \
             jq -r '[.[] | select(.cycle | test("^3\\.[0-9]+$"))] | .[0].cycle')
@@ -25,12 +29,28 @@ jobs:
           echo "Latest stable Python: $latest"
           echo "Known latest: $LATEST_KNOWN_PYTHON"
 
-          if [ "$latest" != "$LATEST_KNOWN_PYTHON" ]; then
-            echo "::warning::New Python version $latest is available! Manual update is required."
-
-            echo "## :warning: New Python Version Available" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Python **$latest** has been released (currently testing up to $LATEST_KNOWN_PYTHON)." >> $GITHUB_STEP_SUMMARY
-          else
+          if [ "$latest" = "$LATEST_KNOWN_PYTHON" ]; then
             echo "Python version is up to date."
+            exit 0
           fi
+
+          # Check if an issue already exists
+          existing=$(gh issue list --label "python-version" --state open --json number -q '.[0].number')
+
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already exists, skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "Update Python support to $latest" \
+            --label "python-version" \
+            --body "$(cat <<EOF
+          Python **$latest** has been released (currently testing up to **$LATEST_KNOWN_PYTHON**).
+
+          ## Required changes
+          - [ ] Add \`$latest\` to the Python matrix in \`.github/workflows/build.yml\` (line 19)
+          - [ ] Add \`Programming Language :: Python :: $latest\` classifier in \`setup.py\` (line 131)
+          - [ ] Update \`LATEST_KNOWN_PYTHON\` to \`$latest\` in \`.github/workflows/weekly.yml\` (line 9)
+          EOF
+          )"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -49,8 +49,8 @@ jobs:
           Python **$latest** has been released (currently testing up to **$LATEST_KNOWN_PYTHON**).
 
           ## Required changes
-          - [ ] Add \`$latest\` to the Python matrix in \`.github/workflows/build.yml\` (line 19)
-          - [ ] Add \`Programming Language :: Python :: $latest\` classifier in \`setup.py\` (line 131)
-          - [ ] Update \`LATEST_KNOWN_PYTHON\` to \`$latest\` in \`.github/workflows/weekly.yml\` (line 9)
+          - [ ] Add \`$latest\` to the Python matrix in \`.github/workflows/build.yml\` (jobs/setup/strategy/matrix/python)
+          - [ ] Add \`Programming Language :: Python :: $latest\` classifier in \`setup.py\` (in the `classifiers=[...]`)
+          - [ ] Update \`LATEST_KNOWN_PYTHON\` to \`$latest\` in \`.github/workflows/weekly.yml\` (beggining of the file, env section)
           EOF
           )"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Build](https://github.com/eclipse-ankaios/ank-sdk-python/actions/workflows/build.yml/badge.svg?job=build)
 ![PyPI - Version](https://img.shields.io/pypi/v/ankaios_sdk)
-![Python](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)
+![Python](https://img.shields.io/pypi/pyversions/ankaios_sdk)
 
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 [![Ankaios](https://img.shields.io/badge/main_project-repo-blue)](https://github.com/eclipse-ankaios/ankaios)


### PR DESCRIPTION
# Description

The current workflow for new python versions is to post a warning in the action itself, but that is not visible enough.
This PR makes it so that a new issue is created with a custom label and it's description contains everything that needs to be done in order to check the latest python version.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
