### PR TITLE
Fix bug in apply_workload regarding sending an empty mask

### DIFF
--- a/ankaios_sdk/ankaios.py
+++ b/ankaios_sdk/ankaios.py
@@ -498,8 +498,13 @@ class Ankaios:
         :raises ConnectionClosedException: If the connection is closed.
         """
         # Create the request
+        masks = (
+            workload._masks
+            if workload._masks
+            else [workload._main_mask]
+        )
         request = UpdateStateRequest(
-            CompleteState(workloads=[workload]), workload._masks
+            CompleteState(workloads=[workload]), masks
         )
 
         # Send request

--- a/examples/manifest.yaml
+++ b/examples/manifest.yaml
@@ -7,7 +7,7 @@ workloads:
       allowRules:
         - type: StateRule
           operation: ReadWrite
-          filterMask:
+          filterMasks:
             - "*"
         - type: LogRule
           workloadNames:

--- a/tests/test_ankaios.py
+++ b/tests/test_ankaios.py
@@ -387,6 +387,20 @@ def test_apply_workload():
         mock_send_request.assert_called_once()
         ankaios.logger.error.assert_called()
 
+    # Test workload with no masks: main mask should be used as fallback
+    workload_no_masks = generate_test_workload()
+    workload_no_masks._masks = []
+    with patch("ankaios_sdk.Ankaios._send_request") as mock_send_request:
+        mock_send_request.return_value = Response(
+            MESSAGE_BUFFER_UPDATE_SUCCESS
+        )
+        ankaios.apply_workload(workload_no_masks)
+        mock_send_request.assert_called_once()
+        request = mock_send_request.call_args[0][0]
+        assert list(request._request.updateStateRequest.updateMask) == [
+            workload_no_masks._main_mask
+        ]
+
 
 def test_get_workload():
     """


### PR DESCRIPTION
# Description

Same issue that was fixed in the Rust SDK by https://github.com/eclipse-ankaios/ank-sdk-rust/pull/65

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
