### PR TITLE
Fix main branch missing in release documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
       - uses: ./.github/actions/ci-setup


### PR DESCRIPTION
# Description

The release job runs with a DETACHED checkout, and the documentation must have access to all branches it want to create the documentation on. Because of this, main needs to be added to the checkout refs so that it is available.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
