### PR TITLE
Update gh actions to Node 24

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
# Description

There are some warning regarding the deprecation of Node.js 20 (example: https://github.com/eclipse-ankaios/ank-sdk-python/actions/runs/23045148641). The fix is to migrate to newer versions of the actions which support Node.js 24.

| Action name | Status |
| --------------| -------- |
| actions/setup-python | Fixed |
| actions/configure-pages | Waiting on their PR (https://github.com/actions/configure-pages/pull/186) |
| actions/deploy-pages | Waiting on their PR (https://github.com/actions/deploy-pages/pull/404 / https://github.com/actions/deploy-pages/pull/409) |

This PR is blocked until all actions are updated.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
