### PR TITLE
Fix complete_state.to_dict

### DIFF
--- a/ankaios_sdk/_components/complete_state.py
+++ b/ankaios_sdk/_components/complete_state.py
@@ -285,25 +285,25 @@ class CompleteState:
         :rtype: dict
         """
         data = {
-            "desired_state": {
-                "api_version": self.get_api_version(),
+            "desiredState": {
+                "apiVersion": self.get_api_version(),
                 "workloads": {},
                 "configs": self.get_configs(),
             },
-            "workload_states": {},
+            "workloadStates": {},
             "agents": {},
         }
         for workload in self.get_workloads():
-            data["desired_state"]["workloads"][
+            data["desiredState"]["workloads"][
                 workload.name
             ] = workload.to_dict()
         wl_states = self.get_workload_states().get_as_dict()
         for agent_name, exec_states in wl_states.items():
-            data["workload_states"][agent_name] = {}
+            data["workloadStates"][agent_name] = {}
             for workload_name, exec_states_id in exec_states.items():
-                data["workload_states"][agent_name][workload_name] = {}
+                data["workloadStates"][agent_name][workload_name] = {}
                 for workload_id, exec_state in exec_states_id.items():
-                    data["workload_states"][agent_name][workload_name][
+                    data["workloadStates"][agent_name][workload_name][
                         workload_id
                     ] = exec_state.to_dict()
         data["agents"] = {}

--- a/tests/test_complete_state.py
+++ b/tests/test_complete_state.py
@@ -193,8 +193,8 @@ def test_to_dict():
 
     complete_state_dict = complete_state.to_dict()
     assert complete_state_dict == {
-        "desired_state": {
-            "api_version": "v1",
+        "desiredState": {
+            "apiVersion": "v1",
             "workloads": {
                 "dynamic_nginx": {
                     "agent": "agent_A",
@@ -247,7 +247,7 @@ def test_to_dict():
                 "config_3": {"key_1": "val_4", "key_2": "val_5"},
             },
         },
-        "workload_states": {
+        "workloadStates": {
             "agent_B": {
                 "nginx": {
                     "5678": {


### PR DESCRIPTION
# Description

If you want to use the events features, the masks and the complete state dictionary are not compatible. This PR makes sure the masks can be applied directly on the dictionary to get the required fields.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
