### PR TITLE
Fix sonar scan checkout issue

### DIFF
--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
       - name: Download analysis reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -54,11 +59,6 @@ jobs:
             echo "head_ref=$(jq -r .headRef reports/pr.json)"
             echo "base_ref=$(jq -r .baseRef reports/pr.json)"
           } >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: refs/pull/${{ steps.pr.outputs.number }}/head
-          fetch-depth: 0
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1


### PR DESCRIPTION
# Description

The sonar job was downloading the reports and then doing checkout, which was deleting the already fetched reports. This PR fixed the issue.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ank-sdk-python/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
